### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0](https://github.com/stack-rs/mitosis/compare/mito-v0.1.0...mito-v0.2.0) - 2024-11-15
+
+### Features
+
+- *(api)* Support attachment metadata query - ([c9d6637](https://github.com/stack-rs/mitosis/commit/c9d66377959c9d1472f8fc036a3e1c746be88940))
+- *(client)* Enhance client prompt - ([9c39cfd](https://github.com/stack-rs/mitosis/commit/9c39cfd094a7754a7542d48263ddbe422de06e91))
+- *(sdk)* Add attachment meta query to client - ([1537968](https://github.com/stack-rs/mitosis/commit/1537968d099e6650299eb9f54be0058465d11d33))
+
+### Documentation
+
+- Update installation guide - ([435f839](https://github.com/stack-rs/mitosis/commit/435f839f028a096e2c37781bfe8d1a2774252f41))
+
+### Miscellaneous Tasks
+
+- Change pr name of release-plz - ([9d94dcc](https://github.com/stack-rs/mitosis/commit/9d94dcc39024e12647d1b7a688aa8661240e234e))
+
 ## [0.1.0](https://github.com/stack-rs/mitosis/releases/tag/mito-v0.1.0) - 2024-11-05
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.60.0"
+version = "1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0506cc60e392e33712d47717d5ae5760a3b134bf8ee7aea7e43df3d7e2669ae0"
+checksum = "0e531658a0397d22365dfe26c3e1c0c8448bf6a3a2d8a098ded802f2b1261615"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
+checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
  "shlex",
 ]
@@ -1249,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "mito"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "netmito",
@@ -2252,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "netmito"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "argon2",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "netmito"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 homepage = "https://github.com/stack-rs/mitosis"
 repository = "https://github.com/stack-rs/mitosis"
@@ -68,7 +68,7 @@ categories.workspace = true
 
 [dependencies]
 clap ={ workspace = true }
-netmito = { path = "netmito" , version = "0.1.0" }
+netmito = { path = "netmito" , version = "0.2.0" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `mito`: 0.1.0 -> 0.2.0
* `netmito`: 0.1.0 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `netmito` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant GetCommands:AttachmentMeta in /tmp/.tmp1EUXQi/mitosis/netmito/src/config/client.rs:148
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `mito`
<blockquote>

## [0.2.0](https://github.com/stack-rs/mitosis/compare/mito-v0.1.0...mito-v0.2.0) - 2024-11-15

### Features

- *(api)* Support attachment metadata query - ([c9d6637](https://github.com/stack-rs/mitosis/commit/c9d66377959c9d1472f8fc036a3e1c746be88940))
- *(client)* Enhance client prompt - ([9c39cfd](https://github.com/stack-rs/mitosis/commit/9c39cfd094a7754a7542d48263ddbe422de06e91))
- *(sdk)* Add attachment meta query to client - ([1537968](https://github.com/stack-rs/mitosis/commit/1537968d099e6650299eb9f54be0058465d11d33))

### Documentation

- Update installation guide - ([435f839](https://github.com/stack-rs/mitosis/commit/435f839f028a096e2c37781bfe8d1a2774252f41))

### Miscellaneous Tasks

- Change pr name of release-plz - ([9d94dcc](https://github.com/stack-rs/mitosis/commit/9d94dcc39024e12647d1b7a688aa8661240e234e))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).