### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.2](https://github.com/stack-rs/mitosis/compare/mito-v0.3.1...mito-v0.3.2) - 2025-07-08
+
+### Miscellaneous Tasks
+
+- *(dist)* Fix dist runner image - ([b76d7d0](https://github.com/stack-rs/mitosis/commit/b76d7d0658479e51d097c285ff54a5c2e37862e4))
+
 ## [0.3.1](https://github.com/stack-rs/mitosis/compare/mito-v0.3.0...mito-v0.3.1) - 2025-07-08
 
 ### Styling

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "mito"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "netmito",
@@ -2388,7 +2388,7 @@ dependencies = [
 
 [[package]]
 name = "netmito"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "argon2",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "netmito"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 homepage = "https://github.com/stack-rs/mitosis"
 repository = "https://github.com/stack-rs/mitosis"
@@ -52,7 +52,7 @@ categories.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-netmito = { path = "netmito", version = "0.3.1" }
+netmito = { path = "netmito", version = "0.3.2" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `netmito`: 0.3.1 -> 0.3.2
* `mito`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>


## `mito`

<blockquote>

## [0.3.2](https://github.com/stack-rs/mitosis/compare/mito-v0.3.1...mito-v0.3.2) - 2025-07-08

### Miscellaneous Tasks

- *(dist)* Fix dist runner image - ([b76d7d0](https://github.com/stack-rs/mitosis/commit/b76d7d0658479e51d097c285ff54a5c2e37862e4))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).