### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0](https://github.com/stack-rs/mitosis/compare/mito-v0.4.0...mito-v0.5.0) - 2025-08-26
+
+### Features
+
+- *(api)* Support admin change group storage quota - ([c7c8d60](https://github.com/stack-rs/mitosis/commit/c7c8d60aa8c13eb80c8c3d08c482381f7231c4a2))
+- *(api)* Support change password - ([9a52468](https://github.com/stack-rs/mitosis/commit/9a524680ab1b038f220ee51fa98904f1f413b900))
+- *(api)* Return username for auth interface - ([2bb8999](https://github.com/stack-rs/mitosis/commit/2bb899949b1b88186571486d1056c3e482c8e8d9))
+- *(api)* Support delete artifact and attachment - ([332998f](https://github.com/stack-rs/mitosis/commit/332998ff002e052c76c7561b5799d391f1389952))
+- *(api)* Support complex query for tasks - ([7c0564d](https://github.com/stack-rs/mitosis/commit/7c0564df838bc98edb12b61a8fdfd73f9699d36d))
+- *(api)* Support query counts only for attachments - ([520aca7](https://github.com/stack-rs/mitosis/commit/520aca76afb3fc55ab82104834ea5ed44329faf7))
+- *(api)* Support query counts only for workers - ([5ae022b](https://github.com/stack-rs/mitosis/commit/5ae022b0bc37c67a9888ea7e7d7584ede18dd597))
+- *(api)* Allow CORS - ([2caf034](https://github.com/stack-rs/mitosis/commit/2caf034119d640de31fecff4d80e08933cbb99a5))
+- *(auth)* Allow user to retain previous login - ([6593fe4](https://github.com/stack-rs/mitosis/commit/6593fe488a78d1ec5b57bbdf83760d961e7803af))
+- *(conf)* Add default value for ClientConfig - ([7e4a247](https://github.com/stack-rs/mitosis/commit/7e4a247f79bc53e2e24b3a5cbee64b1a5066a639))
+- *(conf)* Support read global config file - ([bc552dd](https://github.com/stack-rs/mitosis/commit/bc552ddc4e53971837c7fd89df56750b44967157))
+- *(s3)* Allow more time for uploading - ([75fd9ea](https://github.com/stack-rs/mitosis/commit/75fd9ea3d589f1b66961f186e7eaad9d5b99b637))
+- *(sdk)* Support progress bar for file operation - ([65dcd81](https://github.com/stack-rs/mitosis/commit/65dcd812916f1638d486f11128be6ee0d0299eb5))
+- *(sdk)* Add smart parse for file path arguments - ([ed07a62](https://github.com/stack-rs/mitosis/commit/ed07a62a65626367abc43744aa06d212bf3b2498))
+- *(sdk)* Auto-fill the omitted file name on uploading - ([679d833](https://github.com/stack-rs/mitosis/commit/679d833faf863e66df2c09834742defeede56f68))
+- *(sdk)* Support directly run external commands - ([e917fad](https://github.com/stack-rs/mitosis/commit/e917fad2611df93a2ded8136386b83b5164aff16))
+
+### Bug Fixes
+
+- *(api)* Add middleware to redis interface - ([a6bfc7f](https://github.com/stack-rs/mitosis/commit/a6bfc7f370fc61213783a40457941b18909c44b1))
+- *(worker)* Try to mitigate heartbeat update deadlock - ([0e7116c](https://github.com/stack-rs/mitosis/commit/0e7116c7c4be82a6507fd3dc948d19eac0010154))
+- Sync routes in different feature flags - ([32ffc7e](https://github.com/stack-rs/mitosis/commit/32ffc7e70e6771dfba3c34055bd88fb428b395a2))
+
+### Refactor
+
+- *(task)* Get group name before permission check - ([c1b1c05](https://github.com/stack-rs/mitosis/commit/c1b1c059f9f4ce892803a9b996e7ee6b7a6058c9))
+- [**breaking**] Reorganize api interfaces and client sdk - ([4725e24](https://github.com/stack-rs/mitosis/commit/4725e2417d64c1eb286eb9483f3ec2852608a863))
+
+### Documentation
+
+- *(example)* Add retain option to example config - ([56b1219](https://github.com/stack-rs/mitosis/commit/56b1219a7efb5f4d38bd1e7241aeefc57548c8d8))
+- *(guide)* Update usage guidance - ([046bff2](https://github.com/stack-rs/mitosis/commit/046bff234440a54ea276a347e10acc44169d73cc))
+- Fix wrong comments - ([de8e713](https://github.com/stack-rs/mitosis/commit/de8e7137fb7a8b0e019e30064ce17667d769577b))
+
+### Styling
+
+- Format docker-compose.yml - ([4798760](https://github.com/stack-rs/mitosis/commit/4798760544970f81470598204f47309f65f919b1))
+- Fix clippy warnings - ([f2f5342](https://github.com/stack-rs/mitosis/commit/f2f53429312e78fa562c726d7d38e20bf35e6845))
+
+### Miscellaneous Tasks
+
+- Allow build CI to run from fork's PR - ([0601b0c](https://github.com/stack-rs/mitosis/commit/0601b0c4457924a7d3b6ccc0f4d92382cdf26eae))
+- Replace latest version on docs build - ([2f74600](https://github.com/stack-rs/mitosis/commit/2f74600706de46e7d8a518d280b30f73863a5e38))
+- Downgrade fetch task tracing level - ([94797a9](https://github.com/stack-rs/mitosis/commit/94797a905f9e2852fcf9e7cdc909fed16dec96cf))
+- Re-export some third-party libraries - ([634b3d6](https://github.com/stack-rs/mitosis/commit/634b3d600782e2a53a393c7092a8d8a8018610dd))
+- Impl clone trait for schema data structure - ([c1f3e3c](https://github.com/stack-rs/mitosis/commit/c1f3e3c285afd9c0ea245aa295018f055840036f))
+
+### Build
+
+- *(dist)* Replace native-tls with rustls - ([c36f5c8](https://github.com/stack-rs/mitosis/commit/c36f5c89d04dea67f411a22ab893668ed7b98a3e))
+- *(dist)* Add new target x86_64-unknown-linux-musl - ([48aab5e](https://github.com/stack-rs/mitosis/commit/48aab5e0d407c037ddfc8cd5d34a34b148a3d8a0))
+
 ## [0.4.0](https://github.com/stack-rs/mitosis/compare/mito-v0.3.2...mito-v0.4.0) - 2025-07-22
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,10 +123,12 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
+checksum = "6448dfb3960f0b038e88c781ead1e7eb7929dfc3a71a1336ec9086c00f6d1e75"
 dependencies = [
+ "compression-codecs",
+ "compression-core",
  "flate2",
  "futures-core",
  "memchr",
@@ -672,7 +674,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -697,9 +699,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a65b545ab31d687cff52899d4890855fec459eb6afe0da6417b8a18da87aa29"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 dependencies = [
  "serde",
 ]
@@ -910,6 +912,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46cc6539bf1c592cff488b9f253b30bc0ec50d15407c2cf45e27bd8f308d5905"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2957e823c15bde7ecf1e8b64e537aa03a6be5fda0e2334e99887669e75b12e01"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,7 +1073,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -1919,7 +1940,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2066,9 +2087,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2106,11 +2127,11 @@ checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "libc",
 ]
@@ -2133,11 +2154,11 @@ dependencies = [
 
 [[package]]
 name = "is_executable"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a1b5bad6f9072935961dfbf1cced2f3d129963d091b6f69f007fe04e758ae2"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
 dependencies = [
- "winapi",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2163,9 +2184,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
@@ -2224,7 +2245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2239,7 +2260,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "libc",
  "redox_syscall 0.5.17",
 ]
@@ -2381,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "mito"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "clap",
  "netmito",
@@ -2392,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "netmito"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "argon2",
  "async-compression",
@@ -2449,7 +2470,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2938,16 +2959,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3061,7 +3082,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]
@@ -3097,14 +3118,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
+ "regex-automata 0.4.10",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -3118,20 +3139,20 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
 name = "regex-lite"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+checksum = "943f41321c63ef1c92fd763bfe054d2668f7f225a5c29f0105903dc2fc04ba30"
 
 [[package]]
 name = "regex-syntax"
@@ -3141,9 +3162,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
@@ -3305,7 +3326,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -3318,7 +3339,7 @@ version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -3626,7 +3647,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3639,7 +3660,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -3991,7 +4012,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "byteorder",
  "bytes",
  "crc",
@@ -4035,7 +4056,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "byteorder",
  "crc",
  "dotenvy",
@@ -4192,7 +4213,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -4465,7 +4486,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
  "bytes",
  "futures-util",
  "http 1.3.1",
@@ -4649,9 +4670,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.6"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137a3c834eaf7139b73688502f3f1141a0337c5d8e4d9b536f9b8c796e26a7c4"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -5206,9 +5227,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
@@ -5219,7 +5240,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.2",
+ "bitflags 2.9.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "netmito"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 homepage = "https://github.com/stack-rs/mitosis"
 repository = "https://github.com/stack-rs/mitosis"
@@ -52,7 +52,7 @@ categories.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-netmito = { path = "netmito", version = "0.4.0" }
+netmito = { path = "netmito", version = "0.5.0" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `netmito`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `mito`: 0.4.0 -> 0.5.0

### ⚠ `netmito` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field WorkerConfigCli.retain in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/worker.rs:89
  field WorkerConfigCli.retain in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/worker.rs:89
  field RemoveWorkerGroupArgs.uuid in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/workers.rs:67
  field AttachmentsQueryReq.count in /tmp/.tmpYxDMRx/mitosis/netmito/src/schema.rs:312
  field SubmitTaskArgs.envs in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/tasks.rs:55
  field SubmitTaskArgs.terminal_output in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/tasks.rs:58
  field SubmitTaskArgs.command in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/tasks.rs:61
  field SubmitTaskArgs.resources in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/tasks.rs:63
  field SubmitTaskArgs.watch in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/tasks.rs:67
  field ClientConfigCli.retain in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/mod.rs:65
  field ClientConfigCli.retain in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/mod.rs:65
  field CancelWorkerArgs.uuid in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/workers.rs:39
  field ChangeTaskArgs.uuid in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/tasks.rs:131
  field UpdateWorkerGroupArgs.uuid in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/workers.rs:58
  field UploadAttachmentArgs.pb in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/attachments.rs:47
  field UploadAttachmentArgs.smart in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/attachments.rs:51
  field WorkersQueryResp.count in /tmp/.tmpYxDMRx/mitosis/netmito/src/schema.rs:378
  field UpdateTaskLabelsArgs.uuid in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/tasks.rs:122
  field UpdateTaskLabelsArgs.labels in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/tasks.rs:125
  field RemoveUserGroupArgs.group in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/groups.rs:52
  field TasksQueryReq.creator_usernames in /tmp/.tmpYxDMRx/mitosis/netmito/src/schema.rs:274
  field TasksQueryReq.states in /tmp/.tmpYxDMRx/mitosis/netmito/src/schema.rs:278
  field TasksQueryReq.exit_status in /tmp/.tmpYxDMRx/mitosis/netmito/src/schema.rs:279
  field TasksQueryReq.priority in /tmp/.tmpYxDMRx/mitosis/netmito/src/schema.rs:280
  field TasksQueryReq.count in /tmp/.tmpYxDMRx/mitosis/netmito/src/schema.rs:283
  field UserLoginReq.retain in /tmp/.tmpYxDMRx/mitosis/netmito/src/schema.rs:29
  field WorkersQueryReq.count in /tmp/.tmpYxDMRx/mitosis/netmito/src/schema.rs:337
  field ReplaceWorkerTagsArgs.uuid in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/workers.rs:49
  field CreateGroupArgs.group in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/groups.rs:31
  field UploadArtifactArgs.pb in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/artifacts.rs:45
  field ClientConfig.retain in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/mod.rs:34
  field ClientConfig.retain in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/mod.rs:34
  field UpdateUserGroupArgs.group in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/groups.rs:43

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_missing.ron

Failed in:
  enum netmito::config::client::ManageCommands, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:180
  enum netmito::config::client::ManageTaskCommands, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:524
  enum netmito::config::client::CreateCommands, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:140
  enum netmito::config::client::ManageGroupCommands, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:577
  enum netmito::config::client::ManageWorkerCommands, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:475
  enum netmito::config::client::UploadCommands, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:172
  enum netmito::config::client::GetCommands, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:148

--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant ClientCommand::Auth in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/mod.rs:84

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:ParseSizeError in /tmp/.tmpYxDMRx/mitosis/netmito/src/error.rs:56
  variant S3Error:DeleteObjectError in /tmp/.tmpYxDMRx/mitosis/netmito/src/error.rs:88
  variant S3Error:DeleteObjectsError in /tmp/.tmpYxDMRx/mitosis/netmito/src/error.rs:90
  variant S3Error:BuildError in /tmp/.tmpYxDMRx/mitosis/netmito/src/error.rs:94
  variant ClientCommand:Admin in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/mod.rs:82
  variant ClientCommand:Login in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/mod.rs:86
  variant ClientCommand:Users in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/mod.rs:88
  variant ClientCommand:Groups in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/mod.rs:90
  variant ClientCommand:Tasks in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/mod.rs:92
  variant ClientCommand:Workers in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/mod.rs:94
  variant ClientCommand:Cmd in /tmp/.tmpYxDMRx/mitosis/netmito/src/config/client/mod.rs:96

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ClientCommand::Create, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:84
  variant ClientCommand::Get, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:89
  variant ClientCommand::Submit, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:91
  variant ClientCommand::Upload, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:93
  variant ClientCommand::Manage, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:95
  variant ClientCommand::Shutdown, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:97

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_missing.ron

Failed in:
  function netmito::api::user::query_workers, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:334
  function netmito::service::s3::get_artifact, previously in file /tmp/.tmp7YCMFR/netmito/src/service/s3.rs:88
  function netmito::api::user::shutdown_worker, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:352
  function netmito::api::user::update_worker_groups, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:393
  function netmito::service::s3::user_get_attachment_db, previously in file /tmp/.tmp7YCMFR/netmito/src/service/s3.rs:345
  function netmito::api::group::create_group, previously in file /tmp/.tmp7YCMFR/netmito/src/api/group.rs:33
  function netmito::api::group::get_group, previously in file /tmp/.tmp7YCMFR/netmito/src/api/group.rs:51
  function netmito::api::group::update_user_group, previously in file /tmp/.tmp7YCMFR/netmito/src/api/group.rs:69
  function netmito::api::worker::download_attachment, previously in file /tmp/.tmp7YCMFR/netmito/src/api/worker.rs:148
  function netmito::api::user::login_user, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:73
  function netmito::service::worker::query_worker_list, previously in file /tmp/.tmp7YCMFR/netmito/src/service/worker/mod.rs:702
  function netmito::api::user::change_task_labels, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:132
  function netmito::api::user::query_task, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:169
  function netmito::api::user::upload_artifact, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:203
  function netmito::api::user::download_artifact, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:221
  function netmito::api::user::upload_attachment, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:239
  function netmito::api::user::download_attachment, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:257
  function netmito::api::user::query_attachments, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:293
  function netmito::api::user::query_redis_connection_info, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:311
  function netmito::api::admin::delete_user, previously in file /tmp/.tmp7YCMFR/netmito/src/api/admin.rs:68
  function netmito::api::admin::change_user_state, previously in file /tmp/.tmp7YCMFR/netmito/src/api/admin.rs:90
  function netmito::api::user::remove_worker_groups, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:412
  function netmito::api::worker::register, previously in file /tmp/.tmp7YCMFR/netmito/src/api/worker.rs:37
  function netmito::api::admin::shutdown_coordinator, previously in file /tmp/.tmp7YCMFR/netmito/src/api/admin.rs:130
  function netmito::api::worker::unregister, previously in file /tmp/.tmp7YCMFR/netmito/src/api/worker.rs:73
  function netmito::service::s3::get_attachment, previously in file /tmp/.tmp7YCMFR/netmito/src/service/s3.rs:275
  function netmito::service::worker::get_worker, previously in file /tmp/.tmp7YCMFR/netmito/src/service/worker/mod.rs:623
  function netmito::api::group::group_router, previously in file /tmp/.tmp7YCMFR/netmito/src/api/group.rs:18
  function netmito::api::worker::fetch_task, previously in file /tmp/.tmp7YCMFR/netmito/src/api/worker.rs:101
  function netmito::api::worker::report_task, previously in file /tmp/.tmp7YCMFR/netmito/src/api/worker.rs:115
  function netmito::api::worker::download_artifact, previously in file /tmp/.tmp7YCMFR/netmito/src/api/worker.rs:130
  function netmito::api::group::remove_user_group, previously in file /tmp/.tmp7YCMFR/netmito/src/api/group.rs:88
  function netmito::api::user::user_router, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:35
  function netmito::api::user::auth_user, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:91
  function netmito::service::task::get_task, previously in file /tmp/.tmp7YCMFR/netmito/src/service/task.rs:375
  function netmito::api::user::cancel_task, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:151
  function netmito::api::user::query_tasks, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:185
  function netmito::service::group::get_group, previously in file /tmp/.tmp7YCMFR/netmito/src/service/group.rs:106
  function netmito::api::admin::create_user, previously in file /tmp/.tmp7YCMFR/netmito/src/api/admin.rs:40
  function netmito::api::user::query_worker, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:318
  function netmito::api::user::replace_worker_tags, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:374
  function netmito::api::admin::shutdown_worker, previously in file /tmp/.tmp7YCMFR/netmito/src/api/admin.rs:108
  function netmito::api::user::query_groups, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:431
  function netmito::api::worker::worker_router, previously in file /tmp/.tmp7YCMFR/netmito/src/api/worker.rs:22
  function netmito::api::worker::heartbeat, previously in file /tmp/.tmp7YCMFR/netmito/src/api/worker.rs:87
  function netmito::api::worker::query_task, previously in file /tmp/.tmp7YCMFR/netmito/src/api/worker.rs:166
  function netmito::service::s3::query_attachment_list, previously in file /tmp/.tmp7YCMFR/netmito/src/service/s3.rs:640
  function netmito::api::user::submit_task, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:95
  function netmito::api::user::change_task, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:113
  function netmito::service::group::create_group, previously in file /tmp/.tmp7YCMFR/netmito/src/service/group.rs:18
  function netmito::service::task::query_task_list, previously in file /tmp/.tmp7YCMFR/netmito/src/service/task.rs:563
  function netmito::api::user::get_attachment_metadata, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:275

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_parameter_count_changed.ron

Failed in:
  netmito::service::auth::cred::get_user_credential now takes 6 parameters instead of 5, in /tmp/.tmpYxDMRx/mitosis/netmito/src/service/auth/cred.rs:144
  netmito::service::auth::user_login now takes 5 parameters instead of 4, in /tmp/.tmpYxDMRx/mitosis/netmito/src/service/auth/mod.rs:106
  netmito::service::s3::download_file now takes 4 parameters instead of 3, in /tmp/.tmpYxDMRx/mitosis/netmito/src/service/s3.rs:786

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  MitoClient::auth_user, previously in file /tmp/.tmp7YCMFR/netmito/src/client.rs:552
  MitoClient::create_user, previously in file /tmp/.tmp7YCMFR/netmito/src/client.rs:564
  MitoClient::get_tasks, previously in file /tmp/.tmp7YCMFR/netmito/src/client.rs:768
  MitoClient::get_attachments, previously in file /tmp/.tmp7YCMFR/netmito/src/client.rs:792
  MitoClient::get_workers, previously in file /tmp/.tmp7YCMFR/netmito/src/client.rs:839
  MitoClient::get_groups, previously in file /tmp/.tmp7YCMFR/netmito/src/client.rs:883
  MitoClient::shutdown_coordinator, previously in file /tmp/.tmp7YCMFR/netmito/src/client.rs:1229

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/method_parameter_count_changed.ron

Failed in:
  netmito::client::MitoClient::cancel_worker now takes 2 parameters instead of 3, in /tmp/.tmpYxDMRx/mitosis/netmito/src/client/mod.rs:678
  netmito::client::MitoClient::replace_worker_tags now takes 2 parameters instead of 3, in /tmp/.tmpYxDMRx/mitosis/netmito/src/client/mod.rs:684
  netmito::client::MitoClient::update_group_worker_roles now takes 2 parameters instead of 3, in /tmp/.tmpYxDMRx/mitosis/netmito/src/client/mod.rs:693
  netmito::client::MitoClient::remove_group_worker_roles now takes 2 parameters instead of 3, in /tmp/.tmpYxDMRx/mitosis/netmito/src/client/mod.rs:702
  netmito::client::MitoClient::update_task_labels now takes 2 parameters instead of 3, in /tmp/.tmpYxDMRx/mitosis/netmito/src/client/mod.rs:715
  netmito::client::MitoClient::change_task now takes 2 parameters instead of 3, in /tmp/.tmpYxDMRx/mitosis/netmito/src/client/mod.rs:724
  netmito::client::MitoClient::update_user_group_roles now takes 2 parameters instead of 3, in /tmp/.tmpYxDMRx/mitosis/netmito/src/client/mod.rs:728
  netmito::client::MitoClient::remove_user_group_roles now takes 2 parameters instead of 3, in /tmp/.tmpYxDMRx/mitosis/netmito/src/client/mod.rs:740

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/module_missing.ron

Failed in:
  mod netmito::api::user, previously in file /tmp/.tmp7YCMFR/netmito/src/api/user.rs:1
  mod netmito::api::worker, previously in file /tmp/.tmp7YCMFR/netmito/src/api/worker.rs:1
  mod netmito::api::group, previously in file /tmp/.tmp7YCMFR/netmito/src/api/group.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct netmito::config::client::GetWorkersArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:420
  struct netmito::config::client::GetAttachmentArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:380
  struct netmito::config::client::ManageWorkerArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:467
  struct netmito::config::client::CreateUserArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:190
  struct netmito::config::client::ManageTaskArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:516
  struct netmito::config::client::ManageGroupArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:569
  struct netmito::config::client::GetArtifactArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:356
  struct netmito::config::client::AuthArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:103
  struct netmito::config::client::CreateArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:111
  struct netmito::config::client::GetArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:117
  struct netmito::config::client::SubmitTaskCmdArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:225
  struct netmito::config::client::UploadArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:123
  struct netmito::config::client::ManageArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:129
  struct netmito::config::client::GetArtifactCmdArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:313
  struct netmito::config::client::GetAttachmentCmdArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:366
  struct netmito::config::client::GetTasksArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:328
  struct netmito::config::client::GetAttachmentsArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:390

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field group_name of struct AttachmentsQueryReq, previously in file /tmp/.tmp7YCMFR/netmito/src/schema.rs:274
  field tags of struct UpdateTaskLabelsArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:537
  field username of struct ChangeUserStateReq, previously in file /tmp/.tmp7YCMFR/netmito/src/schema.rs:42
  field creator_username of struct TasksQueryReq, previously in file /tmp/.tmp7YCMFR/netmito/src/schema.rs:249
  field state of struct TasksQueryReq, previously in file /tmp/.tmp7YCMFR/netmito/src/schema.rs:253
  field name of struct CreateGroupArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:205
  field uuid of struct UploadArtifactReq, previously in file /tmp/.tmp7YCMFR/netmito/src/schema.rs:143
  field group_name of struct UploadAttachmentReq, previously in file /tmp/.tmp7YCMFR/netmito/src/schema.rs:131
  field task_spec of struct SubmitTaskArgs, previously in file /tmp/.tmp7YCMFR/netmito/src/config/client.rs:221
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `mito`

<blockquote>

## [0.5.0](https://github.com/stack-rs/mitosis/compare/mito-v0.4.0...mito-v0.5.0) - 2025-08-26

### Features

- *(api)* Support admin change group storage quota - ([c7c8d60](https://github.com/stack-rs/mitosis/commit/c7c8d60aa8c13eb80c8c3d08c482381f7231c4a2))
- *(api)* Support change password - ([9a52468](https://github.com/stack-rs/mitosis/commit/9a524680ab1b038f220ee51fa98904f1f413b900))
- *(api)* Return username for auth interface - ([2bb8999](https://github.com/stack-rs/mitosis/commit/2bb899949b1b88186571486d1056c3e482c8e8d9))
- *(api)* Support delete artifact and attachment - ([332998f](https://github.com/stack-rs/mitosis/commit/332998ff002e052c76c7561b5799d391f1389952))
- *(api)* Support complex query for tasks - ([7c0564d](https://github.com/stack-rs/mitosis/commit/7c0564df838bc98edb12b61a8fdfd73f9699d36d))
- *(api)* Support query counts only for attachments - ([520aca7](https://github.com/stack-rs/mitosis/commit/520aca76afb3fc55ab82104834ea5ed44329faf7))
- *(api)* Support query counts only for workers - ([5ae022b](https://github.com/stack-rs/mitosis/commit/5ae022b0bc37c67a9888ea7e7d7584ede18dd597))
- *(api)* Allow CORS - ([2caf034](https://github.com/stack-rs/mitosis/commit/2caf034119d640de31fecff4d80e08933cbb99a5))
- *(auth)* Allow user to retain previous login - ([6593fe4](https://github.com/stack-rs/mitosis/commit/6593fe488a78d1ec5b57bbdf83760d961e7803af))
- *(conf)* Add default value for ClientConfig - ([7e4a247](https://github.com/stack-rs/mitosis/commit/7e4a247f79bc53e2e24b3a5cbee64b1a5066a639))
- *(conf)* Support read global config file - ([bc552dd](https://github.com/stack-rs/mitosis/commit/bc552ddc4e53971837c7fd89df56750b44967157))
- *(s3)* Allow more time for uploading - ([75fd9ea](https://github.com/stack-rs/mitosis/commit/75fd9ea3d589f1b66961f186e7eaad9d5b99b637))
- *(sdk)* Support progress bar for file operation - ([65dcd81](https://github.com/stack-rs/mitosis/commit/65dcd812916f1638d486f11128be6ee0d0299eb5))
- *(sdk)* Add smart parse for file path arguments - ([ed07a62](https://github.com/stack-rs/mitosis/commit/ed07a62a65626367abc43744aa06d212bf3b2498))
- *(sdk)* Auto-fill the omitted file name on uploading - ([679d833](https://github.com/stack-rs/mitosis/commit/679d833faf863e66df2c09834742defeede56f68))
- *(sdk)* Support directly run external commands - ([e917fad](https://github.com/stack-rs/mitosis/commit/e917fad2611df93a2ded8136386b83b5164aff16))

### Bug Fixes

- *(api)* Add middleware to redis interface - ([a6bfc7f](https://github.com/stack-rs/mitosis/commit/a6bfc7f370fc61213783a40457941b18909c44b1))
- *(worker)* Try to mitigate heartbeat update deadlock - ([0e7116c](https://github.com/stack-rs/mitosis/commit/0e7116c7c4be82a6507fd3dc948d19eac0010154))
- Sync routes in different feature flags - ([32ffc7e](https://github.com/stack-rs/mitosis/commit/32ffc7e70e6771dfba3c34055bd88fb428b395a2))

### Refactor

- *(task)* Get group name before permission check - ([c1b1c05](https://github.com/stack-rs/mitosis/commit/c1b1c059f9f4ce892803a9b996e7ee6b7a6058c9))
- [**breaking**] Reorganize api interfaces and client sdk - ([4725e24](https://github.com/stack-rs/mitosis/commit/4725e2417d64c1eb286eb9483f3ec2852608a863))

### Documentation

- *(example)* Add retain option to example config - ([56b1219](https://github.com/stack-rs/mitosis/commit/56b1219a7efb5f4d38bd1e7241aeefc57548c8d8))
- *(guide)* Update usage guidance - ([046bff2](https://github.com/stack-rs/mitosis/commit/046bff234440a54ea276a347e10acc44169d73cc))
- Fix wrong comments - ([de8e713](https://github.com/stack-rs/mitosis/commit/de8e7137fb7a8b0e019e30064ce17667d769577b))

### Styling

- Format docker-compose.yml - ([4798760](https://github.com/stack-rs/mitosis/commit/4798760544970f81470598204f47309f65f919b1))
- Fix clippy warnings - ([f2f5342](https://github.com/stack-rs/mitosis/commit/f2f53429312e78fa562c726d7d38e20bf35e6845))

### Miscellaneous Tasks

- Allow build CI to run from fork's PR - ([0601b0c](https://github.com/stack-rs/mitosis/commit/0601b0c4457924a7d3b6ccc0f4d92382cdf26eae))
- Replace latest version on docs build - ([2f74600](https://github.com/stack-rs/mitosis/commit/2f74600706de46e7d8a518d280b30f73863a5e38))
- Downgrade fetch task tracing level - ([94797a9](https://github.com/stack-rs/mitosis/commit/94797a905f9e2852fcf9e7cdc909fed16dec96cf))
- Re-export some third-party libraries - ([634b3d6](https://github.com/stack-rs/mitosis/commit/634b3d600782e2a53a393c7092a8d8a8018610dd))
- Impl clone trait for schema data structure - ([c1f3e3c](https://github.com/stack-rs/mitosis/commit/c1f3e3c285afd9c0ea245aa295018f055840036f))

### Build

- *(dist)* Replace native-tls with rustls - ([c36f5c8](https://github.com/stack-rs/mitosis/commit/c36f5c89d04dea67f411a22ab893668ed7b98a3e))
- *(dist)* Add new target x86_64-unknown-linux-musl - ([48aab5e](https://github.com/stack-rs/mitosis/commit/48aab5e0d407c037ddfc8cd5d34a34b148a3d8a0))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).