### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1](https://github.com/stack-rs/mitosis/compare/mito-v0.5.0...mito-v0.5.1) - 2025-08-26
+
+### Build
+
+- *(dist)* Add runner for x86_64-unknown-linux-musl - ([7ab5be7](https://github.com/stack-rs/mitosis/commit/7ab5be7ae98633f4e85869e4f7a085d00a76e53d))
+
 ## [0.5.0](https://github.com/stack-rs/mitosis/compare/mito-v0.4.0...mito-v0.5.0) - 2025-08-26
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "mito"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "netmito",
@@ -2413,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "netmito"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "argon2",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "netmito"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 homepage = "https://github.com/stack-rs/mitosis"
 repository = "https://github.com/stack-rs/mitosis"
@@ -52,7 +52,7 @@ categories.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-netmito = { path = "netmito", version = "0.5.0" }
+netmito = { path = "netmito", version = "0.5.1" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `netmito`: 0.5.0 -> 0.5.1
* `mito`: 0.5.0 -> 0.5.1

<details><summary><i><b>Changelog</b></i></summary><p>


## `mito`

<blockquote>

## [0.5.1](https://github.com/stack-rs/mitosis/compare/mito-v0.5.0...mito-v0.5.1) - 2025-08-26

### Build

- *(dist)* Add runner for x86_64-unknown-linux-musl - ([7ab5be7](https://github.com/stack-rs/mitosis/commit/7ab5be7ae98633f4e85869e4f7a085d00a76e53d))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).