### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2](https://github.com/stack-rs/mitosis/compare/mito-v0.5.1...mito-v0.5.2) - 2025-08-26
+
+### Features
+
+- *(admin)* [**breaking**] Remove request body for user deletion - ([ddfaa05](https://github.com/stack-rs/mitosis/commit/ddfaa05a454ae79bd3e1d339e2768e533724a111))
+
 ## [0.5.1](https://github.com/stack-rs/mitosis/compare/mito-v0.5.0...mito-v0.5.1) - 2025-08-26
 
 ### Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "mito"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
  "netmito",
@@ -2413,7 +2413,7 @@ dependencies = [
 
 [[package]]
 name = "netmito"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "argon2",
  "async-compression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "netmito"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 homepage = "https://github.com/stack-rs/mitosis"
 repository = "https://github.com/stack-rs/mitosis"
@@ -52,7 +52,7 @@ categories.workspace = true
 
 [dependencies]
 clap = { workspace = true }
-netmito = { path = "netmito", version = "0.5.1" }
+netmito = { path = "netmito", version = "0.5.2" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION


## 🤖 New release

* `netmito`: 0.5.1 -> 0.5.2 (⚠ API breaking changes)
* `mito`: 0.5.1 -> 0.5.2

### ⚠ `netmito` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct netmito::schema::DeleteUserReq, previously in file /tmp/.tmpAWPn7t/netmito/src/schema.rs:54
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `mito`

<blockquote>

## [0.5.2](https://github.com/stack-rs/mitosis/compare/mito-v0.5.1...mito-v0.5.2) - 2025-08-26

### Features

- *(admin)* [**breaking**] Remove request body for user deletion - ([ddfaa05](https://github.com/stack-rs/mitosis/commit/ddfaa05a454ae79bd3e1d339e2768e533724a111))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).