### PR TITLE
feat(worker): support configurable and non-expiring worker tokens

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -29,6 +29,9 @@ file_log = false
 coordinator_addr = "http://127.0.0.1:5000"
 polling_interval = "3m"
 heartbeat_interval = "5m"
+# lifetime controls the worker JWT token lifetime.
+# Use a duration such as "7d", "1h", or "30m"; use "never" to issue a token without exp.
+# If omitted or set to "default", the coordinator default token lifetime is used.
 lifetime = "7d"
 # credential_path is not set
 # user is not set

--- a/guide/src/guide/worker.md
+++ b/guide/src/guide/worker.md
@@ -117,20 +117,12 @@ Options:
           The groups allowed to submit tasks to this worker
   -t, --tags [<TAGS>...]
           The tags of this worker
-  -l, --labels [<LABELS>...]
-          The labels of this worker
       --log-path <LOG_PATH>
           The log file path. If not specified, then the default rolling log file path would be used. If specified, then the log file would be exactly at the path specified
       --file-log
           Enable logging to file
-      --shared-log
-          Enable shared logging across multiple workers with daily rotation (max 3 files)
       --lifetime <LIFETIME>
           The lifetime of the worker token (e.g., 7d, 1year, never)
-      --retain
-          Whether to retain the previous login state without refetching the credential
-      --skip-redis
-          Whether to skip connecting to Redis
   -h, --help
           Print help
   -V, --version
@@ -169,4 +161,6 @@ shared_log = true  # Enable shared rolling logs
 - Linux: `$XDG_CACHE_HOME` or `$HOME/.cache/mitosis`
 - macOS: `$HOME/Library/Caches/mitosis`
 - Windows: `{FOLDERID_LocalAppData}\mitosis`
+```
 
+```

--- a/guide/src/guide/worker.md
+++ b/guide/src/guide/worker.md
@@ -11,7 +11,7 @@ Before starting a Worker, we need to understand the environment inside a Worker.
 The Worker will spawn a new process for each task it runs and set up the following environment variables:
 
 - `MITO_TASK_UUID`: This will be set to the UUID of the task being executed.
-- `MITO_NEW_TASK`: This will be set to the path a file where you can write a new task specification (i.e., SubmitTaskReq) in json format for the Worker to submit it on behalf of you, as a downstream task of the current task.
+- `MITO_NEW_TASK`: This will be set to the path to a file where you can write a new task specification (i.e., SubmitTaskReq) in json format for the Worker to submit it on behalf of you, as a downstream task of the current task.
 - `MITO_UPSTREAM_TASK_UUID`: This will be set to the UUID of the upstream task if the current task is submitted by another task while running.
 - `MITO_RESOURCE_DIR`: This will be set to the path of a directory where you can find the resources (i.e., attachments) of the task.
 - `MITO_RESULT_DIR`: This will be set to the path of a directory where you can store the results of the task. The Worker will pack the directory and upload it as the artifacts of the task if it is not empty.
@@ -20,13 +20,13 @@ The Worker will spawn a new process for each task it runs and set up the followi
 ## Starting a Worker
 
 To start a Worker, you need to provide a TOML file that configures the Worker.
-The TOML file specifies the Worker's configuration, such as the polling (fetching) interval, the URL of the Coordinator, and the the groups allowed to submit tasks to it.
+The TOML file specifies the Worker's configuration, such as the polling (fetching) interval, the URL of the Coordinator, and the groups allowed to submit tasks to it.
 All configuration options are optional and have default values.
 
 The Worker will merge the configuration from the file and the command-line arguments according to the following order (the latter overrides the former):
 
 ```md
-DEFAULT <- `$CONFIG_DIR`/mitosis/config.toml <- config file specified by `cli.config` or loal `config.toml` <- env prefixed by `MITO_` <- cli arguments
+DEFAULT <- `$CONFIG_DIR`/mitosis/config.toml <- config file specified by `cli.config` or local `config.toml` <- env prefixed by `MITO_` <- cli arguments
 
 `$CONFIG_DIR` will be different on different platforms:
 
@@ -42,6 +42,9 @@ Here is an example of a Worker configuration file (you can also refer to `config
 coordinator_addr = "http://127.0.0.1:5000"
 polling_interval = "3m"
 heartbeat_interval = "5m"
+# lifetime controls the worker JWT token lifetime.
+# Use a duration such as "7d", "1h", or "30m"; use "never" to issue a token without exp.
+# If omitted or set to "default", the coordinator default token lifetime is used.
 lifetime = "7d"
 # credential_path is not set
 # user is not set
@@ -53,7 +56,6 @@ file_log = false
 # log_path is not set. It will use the default rolling log file path if file_log is set to true
 #   - If shared_log is enabled and log_path is not set, it will use workers.log in cache directory
 #   - If shared_log is disabled and log_path is not set, it will use {worker_uuid}.log in cache directory
-# lifetime is not set, default to the coordinator's setting
 ```
 
 To start a Worker, run the following command:
@@ -115,12 +117,20 @@ Options:
           The groups allowed to submit tasks to this worker
   -t, --tags [<TAGS>...]
           The tags of this worker
+  -l, --labels [<LABELS>...]
+          The labels of this worker
       --log-path <LOG_PATH>
           The log file path. If not specified, then the default rolling log file path would be used. If specified, then the log file would be exactly at the path specified
       --file-log
           Enable logging to file
+      --shared-log
+          Enable shared logging across multiple workers with daily rotation (max 3 files)
       --lifetime <LIFETIME>
-          The lifetime of the worker to alive (e.g., 7d, 1year)
+          The lifetime of the worker token (e.g., 7d, 1year, never)
+      --retain
+          Whether to retain the previous login state without refetching the credential
+      --skip-redis
+          Whether to skip connecting to Redis
   -h, --help
           Print help
   -V, --version
@@ -160,6 +170,3 @@ shared_log = true  # Enable shared rolling logs
 - macOS: `$HOME/Library/Caches/mitosis`
 - Windows: `{FOLDERID_LocalAppData}\mitosis`
 
-```
-
-```

--- a/netmito/src/config/worker.rs
+++ b/netmito/src/config/worker.rs
@@ -12,7 +12,7 @@ use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{fmt::MakeWriter, layer::SubscriberExt, util::SubscriberInitExt, Layer};
 use url::Url;
 
-use crate::error::Error;
+use crate::{error::Error, schema::WorkerTokenLifetime};
 
 use super::{coordinator::DEFAULT_COORDINATOR_ADDR, TracingGuard};
 
@@ -129,8 +129,8 @@ pub struct WorkerConfig {
     pub(crate) file_log: bool,
     #[serde(default)]
     pub(crate) shared_log: bool,
-    #[serde(with = "humantime_serde")]
-    pub(crate) lifetime: Option<Duration>,
+    #[serde(default)]
+    pub(crate) lifetime: WorkerTokenLifetime,
     #[serde(default)]
     pub(crate) retain: bool,
     #[serde(default)]
@@ -193,7 +193,7 @@ pub struct WorkerConfigCli {
     #[arg(long)]
     #[serde(skip_serializing_if = "<&bool>::not")]
     pub shared_log: bool,
-    /// The lifetime of the worker to alive (e.g., 7d, 1year)
+    /// The lifetime of the worker token (e.g., 7d, 1year, never)
     #[arg(long)]
     #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub lifetime: Option<String>,
@@ -222,7 +222,7 @@ impl Default for WorkerConfig {
             log_path: None,
             file_log: false,
             shared_log: false,
-            lifetime: None,
+            lifetime: WorkerTokenLifetime::Default,
             retain: false,
             skip_redis: false,
         }

--- a/netmito/src/schema.rs
+++ b/netmito/src/schema.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use sea_orm::FromQueryResult;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
@@ -99,14 +99,58 @@ pub struct GroupQueryInfo {
     pub users_in_group: Option<HashMap<String, UserGroupRole>>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub enum WorkerTokenLifetime {
+    #[default]
+    Default,
+    Duration(std::time::Duration),
+    Never,
+}
+
+impl WorkerTokenLifetime {
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Default)
+    }
+}
+
+impl Serialize for WorkerTokenLifetime {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Default => serializer.serialize_str("default"),
+            Self::Duration(duration) => serializer.serialize_str(
+                &humantime_serde::re::humantime::format_duration(*duration).to_string(),
+            ),
+            Self::Never => serializer.serialize_str("never"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for WorkerTokenLifetime {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        match Option::<String>::deserialize(deserializer)?.as_deref() {
+            None => Ok(Self::Default),
+            Some(value) if value.eq_ignore_ascii_case("default") => Ok(Self::Default),
+            Some(value) if value.eq_ignore_ascii_case("never") => Ok(Self::Never),
+            Some(value) => humantime_serde::re::humantime::parse_duration(value)
+                .map(Self::Duration)
+                .map_err(serde::de::Error::custom),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RegisterWorkerReq {
     pub tags: HashSet<String>,
     pub labels: HashSet<String>,
     pub groups: HashSet<String>,
-    #[serde(default)]
-    #[serde(with = "humantime_serde")]
-    pub lifetime: Option<std::time::Duration>,
+    #[serde(default, skip_serializing_if = "WorkerTokenLifetime::is_default")]
+    pub lifetime: WorkerTokenLifetime,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/netmito/src/schema.rs
+++ b/netmito/src/schema.rs
@@ -107,12 +107,6 @@ pub enum WorkerTokenLifetime {
     Never,
 }
 
-impl WorkerTokenLifetime {
-    pub fn is_default(&self) -> bool {
-        matches!(self, Self::Default)
-    }
-}
-
 impl Serialize for WorkerTokenLifetime {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -149,7 +143,7 @@ pub struct RegisterWorkerReq {
     pub tags: HashSet<String>,
     pub labels: HashSet<String>,
     pub groups: HashSet<String>,
-    #[serde(default, skip_serializing_if = "WorkerTokenLifetime::is_default")]
+    #[serde(default)]
     pub lifetime: WorkerTokenLifetime,
 }
 

--- a/netmito/src/service/auth/mod.rs
+++ b/netmito/src/service/auth/mod.rs
@@ -265,8 +265,10 @@ async fn user_auth(db: &DatabaseConnection, bearer: &Bearer) -> Result<User::Mod
     let token = bearer.token();
     let claims = verify_token(token).map_err(|_| AuthError::InvalidToken)?;
     let now = TimeDateTimeWithTimeZone::now_utc();
-    if claims.exp < now {
-        return Err(AuthError::WrongCredentials);
+    match claims.exp {
+        Some(exp) if exp >= now => {}
+        Some(_) => return Err(AuthError::WrongCredentials),
+        None => return Err(AuthError::InvalidToken),
     }
 
     let user = User::Entity::find()
@@ -300,8 +302,10 @@ async fn admin_auth(db: &DatabaseConnection, bearer: &Bearer) -> Result<AuthAdmi
     let token = bearer.token();
     let claims = verify_token(token).map_err(|_| AuthError::InvalidToken)?;
     let now = TimeDateTimeWithTimeZone::now_utc();
-    if claims.exp < now {
-        return Err(AuthError::WrongCredentials);
+    match claims.exp {
+        Some(exp) if exp >= now => {}
+        Some(_) => return Err(AuthError::WrongCredentials),
+        None => return Err(AuthError::InvalidToken),
     }
 
     let user = User::Entity::find()
@@ -337,6 +341,12 @@ pub async fn worker_auth_middleware(
 async fn worker_auth(db: &DatabaseConnection, bearer: &Bearer) -> Result<AuthWorker, AuthError> {
     let token = bearer.token();
     let claims = verify_token(token).map_err(|_| AuthError::InvalidToken)?;
+    if let Some(exp) = claims.exp {
+        let now = TimeDateTimeWithTimeZone::now_utc();
+        if exp < now {
+            return Err(AuthError::WrongCredentials);
+        }
+    }
     let uuid = Uuid::parse_str(&claims.sub).map_err(|_| AuthError::InvalidToken)?;
 
     let worker = Worker::Entity::find()

--- a/netmito/src/service/auth/mod.rs
+++ b/netmito/src/service/auth/mod.rs
@@ -264,11 +264,8 @@ pub async fn user_auth_with_name_middleware(
 async fn user_auth(db: &DatabaseConnection, bearer: &Bearer) -> Result<User::Model, AuthError> {
     let token = bearer.token();
     let claims = verify_token(token).map_err(|_| AuthError::InvalidToken)?;
-    let now = TimeDateTimeWithTimeZone::now_utc();
-    match claims.exp {
-        Some(exp) if exp >= now => {}
-        Some(_) => return Err(AuthError::WrongCredentials),
-        None => return Err(AuthError::InvalidToken),
+    if claims.exp.is_none() {
+        return Err(AuthError::InvalidToken);
     }
 
     let user = User::Entity::find()
@@ -301,11 +298,8 @@ pub async fn admin_auth_middleware(
 async fn admin_auth(db: &DatabaseConnection, bearer: &Bearer) -> Result<AuthAdminUser, AuthError> {
     let token = bearer.token();
     let claims = verify_token(token).map_err(|_| AuthError::InvalidToken)?;
-    let now = TimeDateTimeWithTimeZone::now_utc();
-    match claims.exp {
-        Some(exp) if exp >= now => {}
-        Some(_) => return Err(AuthError::WrongCredentials),
-        None => return Err(AuthError::InvalidToken),
+    if claims.exp.is_none() {
+        return Err(AuthError::InvalidToken);
     }
 
     let user = User::Entity::find()
@@ -341,12 +335,6 @@ pub async fn worker_auth_middleware(
 async fn worker_auth(db: &DatabaseConnection, bearer: &Bearer) -> Result<AuthWorker, AuthError> {
     let token = bearer.token();
     let claims = verify_token(token).map_err(|_| AuthError::InvalidToken)?;
-    if let Some(exp) = claims.exp {
-        let now = TimeDateTimeWithTimeZone::now_utc();
-        if exp < now {
-            return Err(AuthError::WrongCredentials);
-        }
-    }
     let uuid = Uuid::parse_str(&claims.sub).map_err(|_| AuthError::InvalidToken)?;
 
     let worker = Worker::Entity::find()

--- a/netmito/src/service/auth/token.rs
+++ b/netmito/src/service/auth/token.rs
@@ -5,15 +5,22 @@ use jsonwebtoken::EncodingKey;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
-use crate::error::{ApiError, DecodeTokenError};
+use crate::{
+    error::{ApiError, DecodeTokenError},
+    schema::WorkerTokenLifetime,
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TokenClaims<'a> {
     /// username
     pub sub: Cow<'a, str>,
     /// expiry time
-    #[serde(with = "jwt_numeric_date")]
-    pub exp: OffsetDateTime,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "jwt_numeric_date_opt"
+    )]
+    pub exp: Option<OffsetDateTime>,
     /// random number
     pub sign: i64,
 }
@@ -29,7 +36,7 @@ where
         ))?;
     let claims = TokenClaims {
         sub: Cow::from(username.as_ref()),
-        exp: OffsetDateTime::now_utc() + token_ttl.token_expires_in,
+        exp: Some(OffsetDateTime::now_utc() + token_ttl.token_expires_in),
         sign,
     };
 
@@ -44,30 +51,35 @@ where
 pub fn generate_worker_token<T>(
     username: T,
     sign: i64,
-    lifetime: Option<std::time::Duration>,
+    lifetime: WorkerTokenLifetime,
 ) -> crate::error::Result<String>
 where
     T: AsRef<str>,
 {
-    let token_ttl = match lifetime {
-        Some(ttl) => time::Duration::try_from(ttl).map_err(|_| {
-            ApiError::InvalidRequest(format!(
-                "Invalid lifetime {}",
-                humantime_serde::re::humantime::format_duration(ttl)
-            ))
-        })?,
-        None => {
-            crate::config::SERVER_CONFIG
+    let exp = match lifetime {
+        WorkerTokenLifetime::Default => {
+            let token_ttl = crate::config::SERVER_CONFIG
                 .get()
                 .ok_or(crate::error::Error::Custom(
                     "server config not found".to_string(),
                 ))?
-                .token_expires_in
+                .token_expires_in;
+            Some(OffsetDateTime::now_utc() + token_ttl)
         }
+        WorkerTokenLifetime::Duration(ttl) => {
+            let token_ttl = time::Duration::try_from(ttl).map_err(|_| {
+                ApiError::InvalidRequest(format!(
+                    "Invalid lifetime {}",
+                    humantime_serde::re::humantime::format_duration(ttl)
+                ))
+            })?;
+            Some(OffsetDateTime::now_utc() + token_ttl)
+        }
+        WorkerTokenLifetime::Never => None,
     };
     let claims = TokenClaims {
         sub: Cow::from(username.as_ref()),
-        exp: OffsetDateTime::now_utc() + token_ttl,
+        exp,
         sign,
     };
 
@@ -94,7 +106,9 @@ pub fn verify_token(token: &str) -> crate::error::Result<TokenClaims<'_>> {
         .decode(token)
         .map_err(DecodeTokenError::from)?;
     let token = String::from_utf8(token).map_err(DecodeTokenError::from)?;
-    let validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::EdDSA);
+    let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::EdDSA);
+    validation.required_spec_claims.remove("exp");
+    validation.validate_exp = false;
     let decoding_key = crate::config::DECODING_KEY
         .get()
         .ok_or(crate::error::Error::Custom(
@@ -105,24 +119,30 @@ pub fn verify_token(token: &str) -> crate::error::Result<TokenClaims<'_>> {
     Ok(decoded.claims)
 }
 
-mod jwt_numeric_date {
+mod jwt_numeric_date_opt {
     use serde::{self, Deserialize, Deserializer, Serializer};
     use time::OffsetDateTime;
-    /// Serializes an OffsetDateTime to a Unix timestamp (milliseconds since 1970/1/1T00:00:00T)
-    pub fn serialize<S>(date: &OffsetDateTime, serializer: S) -> Result<S::Ok, S::Error>
+
+    pub fn serialize<S>(date: &Option<OffsetDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let timestamp = date.unix_timestamp();
-        serializer.serialize_i64(timestamp)
+        match date {
+            Some(date) => serializer.serialize_some(&date.unix_timestamp()),
+            None => serializer.serialize_none(),
+        }
     }
 
-    /// Attempts to deserialize an i64 and use as a Unix timestamp
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<OffsetDateTime, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<OffsetDateTime>, D::Error>
     where
         D: Deserializer<'de>,
     {
-        OffsetDateTime::from_unix_timestamp(i64::deserialize(deserializer)?)
-            .map_err(|_| serde::de::Error::custom("invalid Unix timestamp value"))
+        let timestamp = Option::<i64>::deserialize(deserializer)?;
+        timestamp
+            .map(|timestamp| {
+                OffsetDateTime::from_unix_timestamp(timestamp)
+                    .map_err(|_| serde::de::Error::custom("invalid Unix timestamp value"))
+            })
+            .transpose()
     }
 }

--- a/netmito/src/service/auth/token.rs
+++ b/netmito/src/service/auth/token.rs
@@ -108,7 +108,6 @@ pub fn verify_token(token: &str) -> crate::error::Result<TokenClaims<'_>> {
     let token = String::from_utf8(token).map_err(DecodeTokenError::from)?;
     let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::EdDSA);
     validation.required_spec_claims.remove("exp");
-    validation.validate_exp = false;
     let decoding_key = crate::config::DECODING_KEY
         .get()
         .ok_or(crate::error::Error::Custom(

--- a/netmito/src/worker.rs
+++ b/netmito/src/worker.rs
@@ -266,7 +266,7 @@ impl MitoWorker {
             tags: config.tags.clone(),
             labels: config.labels.clone(),
             groups: config.groups.clone(),
-            lifetime: config.lifetime,
+            lifetime: config.lifetime.clone(),
         };
         let resp = http_client
             .post(url.as_str())

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2529,6 +2529,7 @@ components:
       type: object
       required:
         - tags
+        - labels
         - groups
       properties:
         tags:
@@ -2540,6 +2541,14 @@ components:
             - gpu
             - cuda
             - python
+        labels:
+          type: array
+          items:
+            type: string
+          description: Worker labels for organization and querying
+          example:
+            - linux
+            - cuda12
         groups:
           type: array
           items:
@@ -2551,7 +2560,7 @@ components:
         lifetime:
           type: string
           nullable: true
-          description: Worker lifetime (e.g. "7d", "1h")
+          description: Worker JWT token lifetime. Use a duration such as "7d", "1h", or "30m"; use "never" to issue a token without exp; use "default", omit the field, or set it to null to use the coordinator default token lifetime.
           example: 7d
 
     RegisterWorkerResp:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2529,7 +2529,6 @@ components:
       type: object
       required:
         - tags
-        - labels
         - groups
       properties:
         tags:
@@ -2541,14 +2540,6 @@ components:
             - gpu
             - cuda
             - python
-        labels:
-          type: array
-          items:
-            type: string
-          description: Worker labels for organization and querying
-          example:
-            - linux
-            - cuda12
         groups:
           type: array
           items:


### PR DESCRIPTION
## Summary

- Support configurable and non-expiring worker JWTs during worker registration
- Allow worker JWTs to omit the `exp` claim when `lifetime` is set to `never`
- Preserve the default worker token expiration behavior when `lifetime` is omitted, `null`, or `default`
- Update the worker config example, worker guide, and OpenAPI schema

## Notes

- This only applies to worker JWTs.
- User/admin tokens still require the `exp` claim.
- Worker deletion still invalidates no-exp worker tokens because worker authentication checks that the worker record exists.

## Checks

- `cargo fmt --all`
- `cargo build`
- `cargo test`
- `cargo clippy --workspace`
- `mdbook build`

`cargo audit` failed locally because the RustSec advisory database could not be fetched from GitHub in the local network environment.