### PR TITLE
fix(client): scope credential cache by coordinator

### DIFF
--- a/guide/src/guide/client.md
+++ b/guide/src/guide/client.md
@@ -31,8 +31,6 @@ mito client -i
 If a user has never logged in or if his/her session has expired, the Client will prompt them to re-input their username and password for authentication.
 Alternatively, they can directly specify their username (`-u`) or password (`-p`) during execution.
 Once authenticated, the Client will retain their credentials in a file for future use.
-Cached credentials are scoped by both the Coordinator address and username, so credentials for the same username on different Coordinators can coexist in the same credential file.
-Credential entries written by previous versions do not contain a Coordinator address and are ignored, so users may need to log in again after upgrading.
 
 We recommend using the interactive mode for most operations, as it provides a more user-friendly experience. It will prompt you something like this:
 

--- a/guide/src/guide/client.md
+++ b/guide/src/guide/client.md
@@ -31,6 +31,8 @@ mito client -i
 If a user has never logged in or if his/her session has expired, the Client will prompt them to re-input their username and password for authentication.
 Alternatively, they can directly specify their username (`-u`) or password (`-p`) during execution.
 Once authenticated, the Client will retain their credentials in a file for future use.
+Cached credentials are scoped by both the Coordinator address and username, so credentials for the same username on different Coordinators can coexist in the same credential file.
+Credential entries written by previous versions do not contain a Coordinator address and are ignored, so users may need to log in again after upgrading.
 
 We recommend using the interactive mode for most operations, as it provides a more user-friendly experience. It will prompt you something like this:
 

--- a/netmito/src/client/http.rs
+++ b/netmito/src/client/http.rs
@@ -137,8 +137,13 @@ impl MitoHttpClient {
                 if let Some(parent) = self.credential_path.parent() {
                     tokio::fs::create_dir_all(parent).await?;
                 }
-                modify_or_append_credential(&self.credential_path, &req.username, &self.credential)
-                    .await?;
+                modify_or_append_credential(
+                    &self.credential_path,
+                    &self.url,
+                    &req.username,
+                    &self.credential,
+                )
+                .await?;
             }
             Ok(())
         } else {
@@ -192,8 +197,13 @@ impl MitoHttpClient {
                 if let Some(parent) = self.credential_path.parent() {
                     tokio::fs::create_dir_all(parent).await?;
                 }
-                modify_or_append_credential(&self.credential_path, &username, &self.credential)
-                    .await?;
+                modify_or_append_credential(
+                    &self.credential_path,
+                    &self.url,
+                    &username,
+                    &self.credential,
+                )
+                .await?;
             }
             Ok(())
         } else {

--- a/netmito/src/service/auth/cred.rs
+++ b/netmito/src/service/auth/cred.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
+use base64::{engine::general_purpose, Engine as _};
 use figment::value::magic::RelativePathBuf;
 use reqwest::Client;
-use serde::{Deserialize, Serialize};
 use tokio::io::AsyncBufReadExt;
 use url::Url;
 
@@ -12,15 +12,22 @@ use crate::{
     service::auth::fill_user_login,
 };
 
-#[derive(Debug, Deserialize, Serialize)]
-struct CachedCredential {
-    coordinator_addr: String,
-    username: String,
-    token: String,
-}
-
 fn normalize_coordinator_addr(url: &Url) -> String {
     url.origin().ascii_serialization()
+}
+
+fn encode_coordinator_addr(url: &Url) -> String {
+    general_purpose::STANDARD.encode(normalize_coordinator_addr(url))
+}
+
+fn parse_cached_credential(line: &str) -> Option<(&str, &str, &str)> {
+    let mut parts = line.split(':');
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some(coordinator_addr), Some(username), Some(credential), None) => {
+            Some((coordinator_addr, username, credential))
+        }
+        _ => None,
+    }
 }
 
 pub trait GetPathBuf {
@@ -90,18 +97,19 @@ async fn extract_credential(
     lines: &mut tokio::io::Lines<tokio::io::BufReader<tokio::fs::File>>,
 ) -> std::io::Result<Option<(String, String)>> {
     while let Some(line) = lines.next_line().await? {
-        let Ok(credential) = serde_json::from_str::<CachedCredential>(&line) else {
+        let Some((cached_coordinator_addr, username, credential)) = parse_cached_credential(&line)
+        else {
             continue;
         };
-        if credential.coordinator_addr != coordinator_addr {
+        if cached_coordinator_addr != coordinator_addr {
             continue;
         }
         if let Some(user) = user {
-            if credential.username != *user {
+            if username != user.as_str() {
                 continue;
             }
         }
-        return Ok(Some((credential.username, credential.token)));
+        return Ok(Some((username.to_owned(), credential.to_owned())));
     }
     Ok(None)
 }
@@ -112,25 +120,21 @@ pub(crate) async fn modify_or_append_credential(
     username: &str,
     token: &str,
 ) -> crate::error::Result<()> {
-    let credential = CachedCredential {
-        coordinator_addr: normalize_coordinator_addr(coordinator_url),
-        username: username.to_owned(),
-        token: token.to_owned(),
-    };
-    let credential_line = serde_json::to_string(&credential)?;
+    let coordinator_addr = encode_coordinator_addr(coordinator_url);
+    let credential_line = format!("{coordinator_addr}:{username}:{token}");
 
     if cred_path.exists() {
         let mut lines = read_lines(cred_path).await?;
         let mut new_lines = Vec::new();
         let mut found = false;
         while let Some(line) = lines.next_line().await? {
-            let Ok(cached_credential) = serde_json::from_str::<CachedCredential>(&line) else {
+            let Some((cached_coordinator_addr, cached_username, _)) =
+                parse_cached_credential(&line)
+            else {
                 new_lines.push(line);
                 continue;
             };
-            if cached_credential.coordinator_addr == credential.coordinator_addr
-                && cached_credential.username == credential.username
-            {
+            if cached_coordinator_addr == coordinator_addr.as_str() && cached_username == username {
                 new_lines.push(credential_line.clone());
                 found = true;
             } else {
@@ -156,7 +160,7 @@ pub async fn get_user_credential(
     password: Option<String>,
     retain: bool,
 ) -> crate::error::Result<(String, String)> {
-    let coordinator_addr = normalize_coordinator_addr(&url);
+    let coordinator_addr = encode_coordinator_addr(&url);
 
     // Try to load credential from file
     let cred_path = cred_path

--- a/netmito/src/service/auth/cred.rs
+++ b/netmito/src/service/auth/cred.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use figment::value::magic::RelativePathBuf;
 use reqwest::Client;
-
+use serde::{Deserialize, Serialize};
 use tokio::io::AsyncBufReadExt;
 use url::Url;
 
@@ -12,14 +12,15 @@ use crate::{
     service::auth::fill_user_login,
 };
 
-macro_rules! expect_two {
-    ($iter:expr) => {{
-        let mut i = $iter;
-        match (i.next(), i.next(), i.next()) {
-            (Some(first), Some(second), None) => Some((first, second)),
-            _ => None,
-        }
-    }};
+#[derive(Debug, Deserialize, Serialize)]
+struct CachedCredential {
+    coordinator_addr: String,
+    username: String,
+    token: String,
+}
+
+fn normalize_coordinator_addr(url: &Url) -> String {
+    url.origin().ascii_serialization()
 }
 
 pub trait GetPathBuf {
@@ -84,58 +85,64 @@ where
 }
 
 async fn extract_credential(
+    coordinator_addr: &str,
     user: Option<&String>,
     lines: &mut tokio::io::Lines<tokio::io::BufReader<tokio::fs::File>>,
 ) -> std::io::Result<Option<(String, String)>> {
-    match user {
-        // Specify the user, let us try to find the credential for the user
-        Some(user) => {
-            let prefix = format!("{user}:");
-            while let Some(line) = lines.next_line().await? {
-                if line.starts_with(&prefix) {
-                    if let Some((username, token)) = expect_two!(line.splitn(2, ':')) {
-                        return Ok(Some((username.to_owned(), token.to_owned())));
-                    }
-                }
-            }
-            Ok(None)
+    while let Some(line) = lines.next_line().await? {
+        let Ok(credential) = serde_json::from_str::<CachedCredential>(&line) else {
+            continue;
+        };
+        if credential.coordinator_addr != coordinator_addr {
+            continue;
         }
-        // No user specified, just use the first line
-        None => {
-            if let Some(line) = lines.next_line().await? {
-                if let Some((username, token)) = expect_two!(line.splitn(2, ':')) {
-                    return Ok(Some((username.to_owned(), token.to_owned())));
-                }
+        if let Some(user) = user {
+            if credential.username != *user {
+                continue;
             }
-            Ok(None)
         }
+        return Ok(Some((credential.username, credential.token)));
     }
+    Ok(None)
 }
 
 pub(crate) async fn modify_or_append_credential(
     cred_path: &std::path::PathBuf,
-    username: &String,
-    token: &String,
-) -> std::io::Result<()> {
+    coordinator_url: &Url,
+    username: &str,
+    token: &str,
+) -> crate::error::Result<()> {
+    let credential = CachedCredential {
+        coordinator_addr: normalize_coordinator_addr(coordinator_url),
+        username: username.to_owned(),
+        token: token.to_owned(),
+    };
+    let credential_line = serde_json::to_string(&credential)?;
+
     if cred_path.exists() {
         let mut lines = read_lines(cred_path).await?;
         let mut new_lines = Vec::new();
-        let prefix = format!("{username}:");
         let mut found = false;
         while let Some(line) = lines.next_line().await? {
-            if line.starts_with(&prefix) {
-                new_lines.push(format!("{username}:{token}"));
+            let Ok(cached_credential) = serde_json::from_str::<CachedCredential>(&line) else {
+                new_lines.push(line);
+                continue;
+            };
+            if cached_credential.coordinator_addr == credential.coordinator_addr
+                && cached_credential.username == credential.username
+            {
+                new_lines.push(credential_line.clone());
                 found = true;
             } else {
                 new_lines.push(line);
             }
         }
         if !found {
-            new_lines.push(format!("{username}:{token}"));
+            new_lines.push(credential_line);
         }
         tokio::fs::write(cred_path, new_lines.join("\n")).await?;
     } else {
-        tokio::fs::write(cred_path, format!("{username}:{token}")).await?;
+        tokio::fs::write(cred_path, credential_line).await?;
     }
     Ok(())
 }
@@ -149,6 +156,8 @@ pub async fn get_user_credential(
     password: Option<String>,
     retain: bool,
 ) -> crate::error::Result<(String, String)> {
+    let coordinator_addr = normalize_coordinator_addr(&url);
+
     // Try to load credential from file
     let cred_path = cred_path
         .map(|p| p.relative())
@@ -165,7 +174,9 @@ pub async fn get_user_credential(
     // Check if the credential is valid
     if cred_path.exists() {
         if let Ok(mut lines) = read_lines(&cred_path).await {
-            if let Some((username, cred)) = extract_credential(user.as_ref(), &mut lines).await? {
+            if let Some((username, cred)) =
+                extract_credential(&coordinator_addr, user.as_ref(), &mut lines).await?
+            {
                 url.set_path("auth");
                 let resp = client
                     .get(url.as_str())
@@ -217,7 +228,7 @@ pub async fn get_user_credential(
         if let Some(parent) = cred_path.parent() {
             tokio::fs::create_dir_all(parent).await?;
         }
-        modify_or_append_credential(&cred_path, &req.username, &token).await?;
+        modify_or_append_credential(&cred_path, &url, &req.username, &token).await?;
         Ok((req.username, token))
     } else {
         let resp = resp.json::<ErrorMsg>().await.map_err(RequestError::from)?;
@@ -261,7 +272,7 @@ where
                 if let Some(parent) = cred_path.parent() {
                     tokio::fs::create_dir_all(parent).await?;
                 }
-                modify_or_append_credential(&cred_path, &user_login.username, &token).await?;
+                modify_or_append_credential(&cred_path, url, &user_login.username, &token).await?;
             }
         }
         Ok(token)


### PR DESCRIPTION
## Summary

- Scope cached credentials by normalized Coordinator address and username.
- Keep credentials for the same username on different Coordinators from overwriting each other.
- Preserve malformed or previous-format credential entries when updating the cache.
- Document that previous-format credential entries are ignored after upgrade.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo build`
- `cargo test --workspace`
- `cargo doc`
- `cd guide && mdbook build`
- Manually verified that:
  - previous-format `username:token` entries are ignored without panic;
  - credentials for a different Coordinator address are not used for the current Coordinator;
  - logging in writes a new credential entry with `coordinator_addr`, `username`, and `token`;
  - credentials for the same username on different Coordinator addresses can coexist;
  - subsequent auth uses the credential scoped to the current Coordinator.

## Notes

- `cargo audit` reports existing dependency advisories unrelated to this change.