### PR TITLE
fix(client): update username after login

### DIFF
--- a/netmito/src/client/mod.rs
+++ b/netmito/src/client/mod.rs
@@ -290,7 +290,10 @@ impl MitoClient {
 
     pub async fn user_login(&mut self, args: LoginArgs) -> crate::error::Result<()> {
         let req = fill_user_login(args.username, args.password, args.retain)?;
-        self.http_client.user_login(req).await
+        let username = req.username.clone();
+        self.http_client.user_login(req).await?;
+        self.username = username;
+        Ok(())
     }
 
     pub async fn user_auth(&mut self) -> crate::error::Result<String> {


### PR DESCRIPTION
## Summary

- Synchronize `MitoClient.username` after a successful user login.
- Keep the existing username unchanged when login authentication fails.
- Ensure login messages, interactive welcome output, and current-user/default-group operations use the newly authenticated user.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo test`
- `cargo doc`
- Manually verified that:
  - a successful non-interactive login reports the new username;
  - `login` followed by interactive mode in the same Client process displays the new username;
  - interactive `login` switches the displayed username to the newly authenticated user;
  - `auth` returns the newly authenticated username;
  - a failed interactive login attempt preserves the previously authenticated user.

## Notes

- `cargo audit` reports existing dependency advisories unrelated to this change.