### PR TITLE
fix(client): honor refresh during initial connect

### DIFF
--- a/netmito/src/client/http.rs
+++ b/netmito/src/client/http.rs
@@ -36,6 +36,7 @@ impl MitoHttpClient {
         credential_path: Option<RelativePathBuf>,
         user: Option<String>,
         password: Option<String>,
+        refresh: bool,
     ) -> crate::error::Result<String> {
         let client_credential_path = credential_path
             .as_ref()
@@ -56,6 +57,7 @@ impl MitoHttpClient {
             self.url.clone(),
             user,
             password,
+            refresh,
         )
         .await?;
         self.credential_path = client_credential_path;

--- a/netmito/src/client/mod.rs
+++ b/netmito/src/client/mod.rs
@@ -84,25 +84,23 @@ impl MitoClient {
 
     pub async fn setup(config: ClientConfig) -> crate::error::Result<Self> {
         tracing::debug!("Client is setting up");
-        let refresh = config.refresh;
         let mut http_client = MitoHttpClient::new(config.coordinator_addr);
         let username = http_client
-            .connect(config.credential_path, config.user, config.password)
+            .connect(
+                config.credential_path,
+                config.user,
+                config.password,
+                config.refresh,
+            )
             .await?;
 
-        let mut client = MitoClient {
+        Ok(MitoClient {
             http_client,
             username,
             redis_client: None,
             redis_pubsub_client: None,
             async_redis_client: None,
-        };
-
-        if refresh {
-            client.refresh_token().await?;
-        }
-
-        Ok(client)
+        })
     }
 
     pub fn http_client(&self) -> &http::MitoHttpClient {

--- a/netmito/src/service/auth/cred.rs
+++ b/netmito/src/service/auth/cred.rs
@@ -198,22 +198,23 @@ pub async fn get_user_credential(
     if cred_path.exists() {
         if let Ok(mut lines) = read_lines(&cred_path).await {
             if let Some((username, cred)) = extract_credential(user.as_ref(), &mut lines).await? {
-                if refresh {
-                    url.set_path("refresh");
-                    let resp = client
-                        .post(url.as_str())
-                        .bearer_auth(&cred)
-                        .send()
-                        .await
-                        .map_err(|e| {
-                            if e.is_request() && e.is_connect() {
-                                url.set_path("");
-                                RequestError::ConnectionError(url.to_string())
-                            } else {
-                                e.into()
-                            }
-                        })?;
-                    if resp.status().is_success() {
+                url.set_path(if refresh { "refresh" } else { "auth" });
+                let request = if refresh {
+                    client.post(url.as_str())
+                } else {
+                    client.get(url.as_str())
+                };
+                let resp = request.bearer_auth(&cred).send().await.map_err(|e| {
+                    if e.is_request() && e.is_connect() {
+                        url.set_path("");
+                        RequestError::ConnectionError(url.to_string())
+                    } else {
+                        e.into()
+                    }
+                })?;
+                let status = resp.status();
+                if status.is_success() {
+                    if refresh {
                         let resp = resp
                             .json::<crate::schema::UserLoginResp>()
                             .await
@@ -221,32 +222,14 @@ pub async fn get_user_credential(
                         let token = resp.token;
                         modify_or_append_credential(&cred_path, &username, &token).await?;
                         return Ok((username, token));
-                    } else if resp.status().is_server_error() {
-                        return Err(ApiError::InternalServerError.into());
-                    }
-                } else {
-                    url.set_path("auth");
-                    let resp = client
-                        .get(url.as_str())
-                        .bearer_auth(&cred)
-                        .send()
-                        .await
-                        .map_err(|e| {
-                            if e.is_request() && e.is_connect() {
-                                url.set_path("");
-                                RequestError::ConnectionError(url.to_string())
-                            } else {
-                                e.into()
-                            }
-                        })?;
-                    if resp.status().is_success() {
+                    } else {
                         let resp_name = resp.text().await.map_err(RequestError::from)?;
                         if resp_name == username {
                             return Ok((username, cred));
                         }
-                    } else if resp.status().is_server_error() {
-                        return Err(ApiError::InternalServerError.into());
                     }
+                } else if status.is_server_error() {
+                    return Err(ApiError::InternalServerError.into());
                 }
             }
         }

--- a/netmito/src/service/auth/cred.rs
+++ b/netmito/src/service/auth/cred.rs
@@ -198,10 +198,11 @@ pub async fn get_user_credential(
     if cred_path.exists() {
         if let Ok(mut lines) = read_lines(&cred_path).await {
             if let Some((username, cred)) = extract_credential(user.as_ref(), &mut lines).await? {
-                url.set_path(if refresh { "refresh" } else { "auth" });
                 let request = if refresh {
+                    url.set_path("refresh");
                     client.post(url.as_str())
                 } else {
+                    url.set_path("auth");
                     client.get(url.as_str())
                 };
                 let resp = request.bearer_auth(&cred).send().await.map_err(|e| {

--- a/netmito/src/service/auth/cred.rs
+++ b/netmito/src/service/auth/cred.rs
@@ -179,6 +179,7 @@ pub async fn get_user_credential(
     mut url: Url,
     user: Option<String>,
     password: Option<String>,
+    refresh: bool,
 ) -> crate::error::Result<(String, String)> {
     // Try to load credential from file
     let cred_path = cred_path
@@ -197,34 +198,62 @@ pub async fn get_user_credential(
     if cred_path.exists() {
         if let Ok(mut lines) = read_lines(&cred_path).await {
             if let Some((username, cred)) = extract_credential(user.as_ref(), &mut lines).await? {
-                url.set_path("auth");
-                let resp = client
-                    .get(url.as_str())
-                    .bearer_auth(&cred)
-                    .send()
-                    .await
-                    .map_err(|e| {
-                        if e.is_request() && e.is_connect() {
-                            url.set_path("");
-                            RequestError::ConnectionError(url.to_string())
-                        } else {
-                            e.into()
-                        }
-                    })?;
-                if resp.status().is_success() {
-                    let resp_name = resp.text().await.map_err(RequestError::from)?;
-                    if resp_name == username {
-                        return Ok((username, cred));
+                if refresh {
+                    url.set_path("refresh");
+                    let resp = client
+                        .post(url.as_str())
+                        .bearer_auth(&cred)
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            if e.is_request() && e.is_connect() {
+                                url.set_path("");
+                                RequestError::ConnectionError(url.to_string())
+                            } else {
+                                e.into()
+                            }
+                        })?;
+                    if resp.status().is_success() {
+                        let resp = resp
+                            .json::<crate::schema::UserLoginResp>()
+                            .await
+                            .map_err(RequestError::from)?;
+                        let token = resp.token;
+                        modify_or_append_credential(&cred_path, &username, &token).await?;
+                        return Ok((username, token));
+                    } else if resp.status().is_server_error() {
+                        return Err(ApiError::InternalServerError.into());
                     }
-                } else if resp.status().is_server_error() {
-                    return Err(ApiError::InternalServerError.into());
+                } else {
+                    url.set_path("auth");
+                    let resp = client
+                        .get(url.as_str())
+                        .bearer_auth(&cred)
+                        .send()
+                        .await
+                        .map_err(|e| {
+                            if e.is_request() && e.is_connect() {
+                                url.set_path("");
+                                RequestError::ConnectionError(url.to_string())
+                            } else {
+                                e.into()
+                            }
+                        })?;
+                    if resp.status().is_success() {
+                        let resp_name = resp.text().await.map_err(RequestError::from)?;
+                        if resp_name == username {
+                            return Ok((username, cred));
+                        }
+                    } else if resp.status().is_server_error() {
+                        return Err(ApiError::InternalServerError.into());
+                    }
                 }
             }
         }
     }
     // Local credential not found or invalid, need to login
     tracing::warn!("Local credential not found or invalid, need to login");
-    let req = fill_user_login(user, password, false)?;
+    let req = fill_user_login(user, password, refresh)?;
     url.set_path("login");
     let resp = client
         .post(url.as_str())

--- a/netmito/src/worker.rs
+++ b/netmito/src/worker.rs
@@ -257,6 +257,7 @@ impl MitoWorker {
             config.coordinator_addr.clone(),
             config.user.take(),
             config.password.take(),
+            false,
         )
         .await?;
         let mut url = config.coordinator_addr.clone();


### PR DESCRIPTION
## Summary

- Honor the Client's `--refresh` option during the initial credential connection.
- Refresh a valid cached credential directly instead of authenticating it first and refreshing it afterward.
- When the cached credential is unavailable or rejected, preserve the existing login fallback while requesting a refreshed credential with `/login(refresh=true)`.
- Preserve the existing Client and Worker behavior when refresh is not requested.

## Validation

- `cargo fmt --all`
- `cargo clippy --workspace`
- `cargo build`
- `cargo doc`
- Manually verified with a mock Coordinator that:
  - a valid cached credential with `--refresh` sends exactly one `/refresh` request, without `/auth` or `/login`;
  - a missing cached credential with `--refresh` sends one `/login` request with `refresh=true`;
  - a rejected cached credential falls back from `/refresh` to `/login` with `refresh=true`;
  - without `--refresh`, the existing `/auth` flow remains unchanged.