### PR TITLE
refactor(auth): centralize credential storage

### DIFF
--- a/netmito/src/client/http.rs
+++ b/netmito/src/client/http.rs
@@ -9,7 +9,10 @@ use crate::{
     entity::content::ArtifactContentType,
     error::{get_error_from_resp, map_reqwest_err, RequestError},
     schema::*,
-    service::auth::cred::{get_user_credential, modify_or_append_credential, remove_credential},
+    service::auth::{
+        cred::get_user_credential,
+        credential_store::{CredentialStore, CredentialWrite},
+    },
 };
 
 pub struct MitoHttpClient {
@@ -134,8 +137,15 @@ impl MitoHttpClient {
                 .map_err(RequestError::from)?;
             self.credential = resp.token;
             if !self.credential_path.as_os_str().is_empty() {
-                modify_or_append_credential(&self.credential_path, &req.username, &self.credential)
-                    .await?;
+                CredentialStore::write(
+                    &self.credential_path,
+                    &self.url,
+                    CredentialWrite::StoreJwt {
+                        username: &req.username,
+                        token: &self.credential,
+                    },
+                )
+                .await?;
             }
             Ok(())
         } else {
@@ -162,9 +172,15 @@ impl MitoHttpClient {
             self.credential = resp.token;
 
             if !self.credential_path.as_os_str().is_empty() {
-                let username = username.to_string();
-                modify_or_append_credential(&self.credential_path, &username, &self.credential)
-                    .await?;
+                CredentialStore::write(
+                    &self.credential_path,
+                    &self.url,
+                    CredentialWrite::StoreJwt {
+                        username,
+                        token: &self.credential,
+                    },
+                )
+                .await?;
             }
 
             Ok(())
@@ -186,10 +202,14 @@ impl MitoHttpClient {
         if resp.status().is_success() {
             self.credential.clear();
 
-            if self.credential_path.exists() {
-                if let Err(e) = remove_credential(&self.credential_path, username).await {
-                    tracing::warn!("Failed to remove local credential for {username}: {e}");
-                }
+            if let Err(e) = CredentialStore::write(
+                &self.credential_path,
+                &self.url,
+                CredentialWrite::RemoveJwt { username },
+            )
+            .await
+            {
+                tracing::warn!("Failed to remove local credential for {username}: {e}");
             }
 
             Ok(())
@@ -241,8 +261,15 @@ impl MitoHttpClient {
                 .map_err(RequestError::from)?;
             self.credential = resp.token;
             if !self.credential_path.as_os_str().is_empty() {
-                modify_or_append_credential(&self.credential_path, &username, &self.credential)
-                    .await?;
+                CredentialStore::write(
+                    &self.credential_path,
+                    &self.url,
+                    CredentialWrite::StoreJwt {
+                        username: &username,
+                        token: &self.credential,
+                    },
+                )
+                .await?;
             }
             Ok(())
         } else {

--- a/netmito/src/client/http.rs
+++ b/netmito/src/client/http.rs
@@ -7,42 +7,43 @@ use crate::{
     entity::content::ArtifactContentType,
     error::{get_error_from_resp, map_reqwest_err, RequestError},
     schema::*,
-    service::auth::{cred::get_user_credential_with_store, credential_store::CredentialStore},
+    service::auth::{cred::get_user_credential, credential_store::CredentialStore},
 };
 
 pub struct MitoHttpClient {
     http_client: Client,
     url: Url,
     credential: String,
-    credential_store: Option<CredentialStore>,
+    credential_store: CredentialStore,
 }
 
 impl MitoHttpClient {
-    pub fn new(mut coordinator_addr: Url) -> Self {
+    pub fn new(
+        mut coordinator_addr: Url,
+        credential_path: Option<RelativePathBuf>,
+    ) -> crate::error::Result<Self> {
         let http_client = Client::new();
+        let credential_store = CredentialStore::new(
+            credential_path.map(|credential_path| credential_path.relative()),
+        )?;
         coordinator_addr.set_path("/");
-        Self {
+
+        Ok(Self {
             http_client,
             url: coordinator_addr,
             credential: String::new(),
-            credential_store: None,
-        }
+            credential_store,
+        })
     }
 
     pub async fn connect(
         &mut self,
-        credential_path: Option<RelativePathBuf>,
         user: Option<String>,
         password: Option<String>,
         refresh: bool,
     ) -> crate::error::Result<String> {
-        let credential_store = CredentialStore::new(
-            credential_path
-                .as_ref()
-                .map(|credential_path| credential_path.relative()),
-        )?;
-        let (username, credential) = get_user_credential_with_store(
-            &credential_store,
+        let (username, credential) = get_user_credential(
+            &self.credential_store,
             &self.http_client,
             self.url.clone(),
             user,
@@ -51,7 +52,6 @@ impl MitoHttpClient {
         )
         .await?;
 
-        self.credential_store = Some(credential_store);
         self.credential = credential;
         Ok(username)
     }
@@ -124,11 +124,9 @@ impl MitoHttpClient {
                 .await
                 .map_err(RequestError::from)?;
             self.credential = resp.token;
-            if let Some(credential_store) = &self.credential_store {
-                credential_store
-                    .write_jwt(&self.url, &req.username, &self.credential)
-                    .await?;
-            }
+            self.credential_store
+                .write_jwt(&self.url, &req.username, &self.credential)
+                .await?;
             Ok(())
         } else {
             Err(get_error_from_resp(resp).await.into())
@@ -153,11 +151,9 @@ impl MitoHttpClient {
 
             self.credential = resp.token;
 
-            if let Some(credential_store) = &self.credential_store {
-                credential_store
-                    .write_jwt(&self.url, username, &self.credential)
-                    .await?;
-            }
+            self.credential_store
+                .write_jwt(&self.url, username, &self.credential)
+                .await?;
 
             Ok(())
         } else {
@@ -178,10 +174,8 @@ impl MitoHttpClient {
         if resp.status().is_success() {
             self.credential.clear();
 
-            if let Some(credential_store) = &self.credential_store {
-                if let Err(e) = credential_store.remove_jwt(&self.url, username).await {
-                    tracing::warn!("Failed to remove local credential for {username}: {e}");
-                }
+            if let Err(e) = self.credential_store.remove_jwt(&self.url, username).await {
+                tracing::warn!("Failed to remove local credential for {username}: {e}");
             }
 
             Ok(())
@@ -232,11 +226,9 @@ impl MitoHttpClient {
                 .await
                 .map_err(RequestError::from)?;
             self.credential = resp.token;
-            if let Some(credential_store) = &self.credential_store {
-                credential_store
-                    .write_jwt(&self.url, &username, &self.credential)
-                    .await?;
-            }
+            self.credential_store
+                .write_jwt(&self.url, &username, &self.credential)
+                .await?;
             Ok(())
         } else {
             Err(get_error_from_resp(resp).await.into())

--- a/netmito/src/client/http.rs
+++ b/netmito/src/client/http.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use figment::value::magic::RelativePathBuf;
 use reqwest::Client;
 use url::Url;
@@ -9,17 +7,14 @@ use crate::{
     entity::content::ArtifactContentType,
     error::{get_error_from_resp, map_reqwest_err, RequestError},
     schema::*,
-    service::auth::{
-        cred::get_user_credential,
-        credential_store::{CredentialStore, CredentialWrite},
-    },
+    service::auth::{cred::get_user_credential_with_store, credential_store::CredentialStore},
 };
 
 pub struct MitoHttpClient {
     http_client: Client,
     url: Url,
     credential: String,
-    credential_path: PathBuf,
+    credential_store: Option<CredentialStore>,
 }
 
 impl MitoHttpClient {
@@ -30,7 +25,7 @@ impl MitoHttpClient {
             http_client,
             url: coordinator_addr,
             credential: String::new(),
-            credential_path: PathBuf::new(),
+            credential_store: None,
         }
     }
 
@@ -41,21 +36,13 @@ impl MitoHttpClient {
         password: Option<String>,
         refresh: bool,
     ) -> crate::error::Result<String> {
-        let client_credential_path = credential_path
-            .as_ref()
-            .map(|p| p.relative())
-            .or_else(|| {
-                dirs::config_dir().map(|mut p| {
-                    p.push("mitosis");
-                    p.push("credentials");
-                    p
-                })
-            })
-            .ok_or(crate::error::Error::ConfigError(Box::new(
-                figment::Error::from("credential path not found"),
-            )))?;
-        let (username, credential) = get_user_credential(
-            credential_path.as_ref(),
+        let credential_store = CredentialStore::new(
+            credential_path
+                .as_ref()
+                .map(|credential_path| credential_path.relative()),
+        )?;
+        let (username, credential) = get_user_credential_with_store(
+            &credential_store,
             &self.http_client,
             self.url.clone(),
             user,
@@ -63,7 +50,8 @@ impl MitoHttpClient {
             refresh,
         )
         .await?;
-        self.credential_path = client_credential_path;
+
+        self.credential_store = Some(credential_store);
         self.credential = credential;
         Ok(username)
     }
@@ -136,16 +124,10 @@ impl MitoHttpClient {
                 .await
                 .map_err(RequestError::from)?;
             self.credential = resp.token;
-            if !self.credential_path.as_os_str().is_empty() {
-                CredentialStore::write(
-                    &self.credential_path,
-                    &self.url,
-                    CredentialWrite::StoreJwt {
-                        username: &req.username,
-                        token: &self.credential,
-                    },
-                )
-                .await?;
+            if let Some(credential_store) = &self.credential_store {
+                credential_store
+                    .write_jwt(&self.url, &req.username, &self.credential)
+                    .await?;
             }
             Ok(())
         } else {
@@ -171,16 +153,10 @@ impl MitoHttpClient {
 
             self.credential = resp.token;
 
-            if !self.credential_path.as_os_str().is_empty() {
-                CredentialStore::write(
-                    &self.credential_path,
-                    &self.url,
-                    CredentialWrite::StoreJwt {
-                        username,
-                        token: &self.credential,
-                    },
-                )
-                .await?;
+            if let Some(credential_store) = &self.credential_store {
+                credential_store
+                    .write_jwt(&self.url, username, &self.credential)
+                    .await?;
             }
 
             Ok(())
@@ -202,14 +178,10 @@ impl MitoHttpClient {
         if resp.status().is_success() {
             self.credential.clear();
 
-            if let Err(e) = CredentialStore::write(
-                &self.credential_path,
-                &self.url,
-                CredentialWrite::RemoveJwt { username },
-            )
-            .await
-            {
-                tracing::warn!("Failed to remove local credential for {username}: {e}");
+            if let Some(credential_store) = &self.credential_store {
+                if let Err(e) = credential_store.remove_jwt(&self.url, username).await {
+                    tracing::warn!("Failed to remove local credential for {username}: {e}");
+                }
             }
 
             Ok(())
@@ -260,16 +232,10 @@ impl MitoHttpClient {
                 .await
                 .map_err(RequestError::from)?;
             self.credential = resp.token;
-            if !self.credential_path.as_os_str().is_empty() {
-                CredentialStore::write(
-                    &self.credential_path,
-                    &self.url,
-                    CredentialWrite::StoreJwt {
-                        username: &username,
-                        token: &self.credential,
-                    },
-                )
-                .await?;
+            if let Some(credential_store) = &self.credential_store {
+                credential_store
+                    .write_jwt(&self.url, &username, &self.credential)
+                    .await?;
             }
             Ok(())
         } else {

--- a/netmito/src/client/mod.rs
+++ b/netmito/src/client/mod.rs
@@ -84,14 +84,9 @@ impl MitoClient {
 
     pub async fn setup(config: ClientConfig) -> crate::error::Result<Self> {
         tracing::debug!("Client is setting up");
-        let mut http_client = MitoHttpClient::new(config.coordinator_addr);
+        let mut http_client = MitoHttpClient::new(config.coordinator_addr, config.credential_path)?;
         let username = http_client
-            .connect(
-                config.credential_path,
-                config.user,
-                config.password,
-                config.refresh,
-            )
+            .connect(config.user, config.password, config.refresh)
             .await?;
 
         Ok(MitoClient {

--- a/netmito/src/service/auth/cred.rs
+++ b/netmito/src/service/auth/cred.rs
@@ -63,20 +63,7 @@ impl GetPathBuf for std::path::Path {
 // }
 
 // The return value is a tuple of username and token
-pub async fn get_user_credential(
-    cred_path: Option<&RelativePathBuf>,
-    client: &Client,
-    url: Url,
-    user: Option<String>,
-    password: Option<String>,
-    refresh: bool,
-) -> crate::error::Result<(String, String)> {
-    let credential_store = CredentialStore::new(cred_path.map(|cred_path| cred_path.relative()))?;
-
-    get_user_credential_with_store(&credential_store, client, url, user, password, refresh).await
-}
-
-pub(crate) async fn get_user_credential_with_store(
+pub(crate) async fn get_user_credential(
     credential_store: &CredentialStore,
     client: &Client,
     mut url: Url,

--- a/netmito/src/service/auth/cred.rs
+++ b/netmito/src/service/auth/cred.rs
@@ -8,10 +8,7 @@ use url::Url;
 use crate::{
     error::{ApiError, Error, ErrorMsg, RequestError},
     schema::UserLoginReq,
-    service::auth::{
-        credential_store::{Credential, CredentialRead, CredentialStore, CredentialWrite},
-        fill_user_login,
-    },
+    service::auth::{credential_store::CredentialStore, fill_user_login},
 };
 
 pub trait GetPathBuf {
@@ -69,37 +66,25 @@ impl GetPathBuf for std::path::Path {
 pub async fn get_user_credential(
     cred_path: Option<&RelativePathBuf>,
     client: &Client,
+    url: Url,
+    user: Option<String>,
+    password: Option<String>,
+    refresh: bool,
+) -> crate::error::Result<(String, String)> {
+    let credential_store = CredentialStore::new(cred_path.map(|cred_path| cred_path.relative()))?;
+
+    get_user_credential_with_store(&credential_store, client, url, user, password, refresh).await
+}
+
+pub(crate) async fn get_user_credential_with_store(
+    credential_store: &CredentialStore,
+    client: &Client,
     mut url: Url,
     user: Option<String>,
     password: Option<String>,
     refresh: bool,
 ) -> crate::error::Result<(String, String)> {
-    // Try to load credential from file
-    let cred_path = cred_path
-        .map(|p| p.relative())
-        .or_else(|| {
-            dirs::config_dir().map(|mut p| {
-                p.push("mitosis");
-                p.push("credentials");
-                p
-            })
-        })
-        .ok_or(Error::ConfigError(Box::new(figment::Error::from(
-            "credential path not found",
-        ))))?;
-    // Check if the credential is valid
-    if let Some(Credential::Jwt {
-        username,
-        token: cred,
-    }) = CredentialStore::read(
-        &cred_path,
-        &url,
-        CredentialRead::Jwt {
-            username: user.as_deref(),
-        },
-    )
-    .await?
-    {
+    if let Some((username, cred)) = credential_store.read_jwt(&url, user.as_deref()).await? {
         let request = if refresh {
             url.set_path("refresh");
             client.post(url.as_str())
@@ -123,15 +108,7 @@ pub async fn get_user_credential(
                     .await
                     .map_err(RequestError::from)?;
                 let token = resp.token;
-                CredentialStore::write(
-                    &cred_path,
-                    &url,
-                    CredentialWrite::StoreJwt {
-                        username: &username,
-                        token: &token,
-                    },
-                )
-                .await?;
+                credential_store.write_jwt(&url, &username, &token).await?;
                 return Ok((username, token));
             } else {
                 let resp_name = resp.text().await.map_err(RequestError::from)?;
@@ -143,7 +120,7 @@ pub async fn get_user_credential(
             return Err(ApiError::InternalServerError.into());
         }
     }
-    // Local credential not found or invalid, need to login
+
     tracing::warn!("Local credential not found or invalid, need to login");
     let req = fill_user_login(user, password, refresh)?;
     url.set_path("login");
@@ -166,15 +143,9 @@ pub async fn get_user_credential(
             .await
             .map_err(RequestError::from)?;
         let token = resp.token;
-        CredentialStore::write(
-            &cred_path,
-            &url,
-            CredentialWrite::StoreJwt {
-                username: &req.username,
-                token: &token,
-            },
-        )
-        .await?;
+        credential_store
+            .write_jwt(&url, &req.username, &token)
+            .await?;
         Ok((req.username, token))
     } else {
         let resp = resp.json::<ErrorMsg>().await.map_err(RequestError::from)?;
@@ -213,16 +184,10 @@ where
             .map_err(RequestError::from)?;
         let token = resp.token;
         if let Some(cred_path) = cred_path {
-            let cred_path = cred_path.get_path_buf();
-            CredentialStore::write(
-                &cred_path,
-                &*url,
-                CredentialWrite::StoreJwt {
-                    username: &user_login.username,
-                    token: &token,
-                },
-            )
-            .await?;
+            let credential_store = CredentialStore::new(Some(cred_path.get_path_buf()))?;
+            credential_store
+                .write_jwt(&*url, &user_login.username, &token)
+                .await?;
         }
         Ok(token)
     } else {

--- a/netmito/src/service/auth/cred.rs
+++ b/netmito/src/service/auth/cred.rs
@@ -3,24 +3,16 @@ use std::path::PathBuf;
 use figment::value::magic::RelativePathBuf;
 use reqwest::Client;
 
-use tokio::io::AsyncBufReadExt;
 use url::Url;
 
 use crate::{
     error::{ApiError, Error, ErrorMsg, RequestError},
     schema::UserLoginReq,
-    service::auth::fill_user_login,
+    service::auth::{
+        credential_store::{Credential, CredentialRead, CredentialStore, CredentialWrite},
+        fill_user_login,
+    },
 };
-
-macro_rules! expect_two {
-    ($iter:expr) => {{
-        let mut i = $iter;
-        match (i.next(), i.next(), i.next()) {
-            (Some(first), Some(second), None) => Some((first, second)),
-            _ => None,
-        }
-    }};
-}
 
 pub trait GetPathBuf {
     fn get_path_buf(&self) -> PathBuf;
@@ -73,105 +65,6 @@ impl GetPathBuf for std::path::Path {
 //     }
 // }
 
-async fn read_lines<P>(
-    filename: P,
-) -> std::io::Result<tokio::io::Lines<tokio::io::BufReader<tokio::fs::File>>>
-where
-    P: AsRef<std::path::Path>,
-{
-    let file = tokio::fs::File::open(filename).await?;
-    Ok(tokio::io::BufReader::new(file).lines())
-}
-
-async fn extract_credential(
-    user: Option<&String>,
-    lines: &mut tokio::io::Lines<tokio::io::BufReader<tokio::fs::File>>,
-) -> std::io::Result<Option<(String, String)>> {
-    match user {
-        // Specify the user, let us try to find the credential for the user
-        Some(user) => {
-            let prefix = format!("{user}:");
-            while let Some(line) = lines.next_line().await? {
-                if line.starts_with(&prefix) {
-                    if let Some((username, token)) = expect_two!(line.splitn(2, ':')) {
-                        return Ok(Some((username.to_owned(), token.to_owned())));
-                    }
-                }
-            }
-            Ok(None)
-        }
-        // No user specified, just use the first line
-        None => {
-            if let Some(line) = lines.next_line().await? {
-                if let Some((username, token)) = expect_two!(line.splitn(2, ':')) {
-                    return Ok(Some((username.to_owned(), token.to_owned())));
-                }
-            }
-            Ok(None)
-        }
-    }
-}
-
-// TODO: we might upgrade our credential storage format to include the coordinator address to avoid
-// conflict
-pub(crate) async fn modify_or_append_credential(
-    cred_path: &std::path::PathBuf,
-    username: &String,
-    token: &String,
-) -> std::io::Result<()> {
-    if let Some(parent) = cred_path.parent().filter(|p| !p.as_os_str().is_empty()) {
-        tokio::fs::create_dir_all(parent).await?;
-    }
-    if cred_path.exists() {
-        let mut lines = read_lines(cred_path).await?;
-        let mut new_lines = Vec::new();
-        let prefix = format!("{username}:");
-        let mut found = false;
-        while let Some(line) = lines.next_line().await? {
-            if line.starts_with(&prefix) {
-                new_lines.push(format!("{username}:{token}"));
-                found = true;
-            } else {
-                new_lines.push(line);
-            }
-        }
-        if !found {
-            new_lines.push(format!("{username}:{token}"));
-        }
-        tokio::fs::write(cred_path, new_lines.join("\n")).await?;
-    } else {
-        tokio::fs::write(cred_path, format!("{username}:{token}")).await?;
-    }
-    Ok(())
-}
-
-pub(crate) async fn remove_credential(
-    cred_path: &std::path::PathBuf,
-    username: &str,
-) -> std::io::Result<()> {
-    if !cred_path.exists() {
-        return Ok(());
-    }
-
-    let mut lines = read_lines(cred_path).await?;
-    let prefix = format!("{username}:");
-    let mut new_lines = Vec::new();
-
-    while let Some(line) = lines.next_line().await? {
-        if !line.starts_with(&prefix) {
-            new_lines.push(line);
-        }
-    }
-
-    if new_lines.is_empty() {
-        tokio::fs::remove_file(cred_path).await?;
-    } else {
-        tokio::fs::write(cred_path, new_lines.join("\n")).await?;
-    }
-
-    Ok(())
-}
-
 // The return value is a tuple of username and token
 pub async fn get_user_credential(
     cred_path: Option<&RelativePathBuf>,
@@ -195,44 +88,59 @@ pub async fn get_user_credential(
             "credential path not found",
         ))))?;
     // Check if the credential is valid
-    if cred_path.exists() {
-        if let Ok(mut lines) = read_lines(&cred_path).await {
-            if let Some((username, cred)) = extract_credential(user.as_ref(), &mut lines).await? {
-                let request = if refresh {
-                    url.set_path("refresh");
-                    client.post(url.as_str())
-                } else {
-                    url.set_path("auth");
-                    client.get(url.as_str())
-                };
-                let resp = request.bearer_auth(&cred).send().await.map_err(|e| {
-                    if e.is_request() && e.is_connect() {
-                        url.set_path("");
-                        RequestError::ConnectionError(url.to_string())
-                    } else {
-                        e.into()
-                    }
-                })?;
-                let status = resp.status();
-                if status.is_success() {
-                    if refresh {
-                        let resp = resp
-                            .json::<crate::schema::UserLoginResp>()
-                            .await
-                            .map_err(RequestError::from)?;
-                        let token = resp.token;
-                        modify_or_append_credential(&cred_path, &username, &token).await?;
-                        return Ok((username, token));
-                    } else {
-                        let resp_name = resp.text().await.map_err(RequestError::from)?;
-                        if resp_name == username {
-                            return Ok((username, cred));
-                        }
-                    }
-                } else if status.is_server_error() {
-                    return Err(ApiError::InternalServerError.into());
+    if let Some(Credential::Jwt {
+        username,
+        token: cred,
+    }) = CredentialStore::read(
+        &cred_path,
+        &url,
+        CredentialRead::Jwt {
+            username: user.as_deref(),
+        },
+    )
+    .await?
+    {
+        let request = if refresh {
+            url.set_path("refresh");
+            client.post(url.as_str())
+        } else {
+            url.set_path("auth");
+            client.get(url.as_str())
+        };
+        let resp = request.bearer_auth(&cred).send().await.map_err(|e| {
+            if e.is_request() && e.is_connect() {
+                url.set_path("");
+                RequestError::ConnectionError(url.to_string())
+            } else {
+                e.into()
+            }
+        })?;
+        let status = resp.status();
+        if status.is_success() {
+            if refresh {
+                let resp = resp
+                    .json::<crate::schema::UserLoginResp>()
+                    .await
+                    .map_err(RequestError::from)?;
+                let token = resp.token;
+                CredentialStore::write(
+                    &cred_path,
+                    &url,
+                    CredentialWrite::StoreJwt {
+                        username: &username,
+                        token: &token,
+                    },
+                )
+                .await?;
+                return Ok((username, token));
+            } else {
+                let resp_name = resp.text().await.map_err(RequestError::from)?;
+                if resp_name == username {
+                    return Ok((username, cred));
                 }
             }
+        } else if status.is_server_error() {
+            return Err(ApiError::InternalServerError.into());
         }
     }
     // Local credential not found or invalid, need to login
@@ -258,7 +166,15 @@ pub async fn get_user_credential(
             .await
             .map_err(RequestError::from)?;
         let token = resp.token;
-        modify_or_append_credential(&cred_path, &req.username, &token).await?;
+        CredentialStore::write(
+            &cred_path,
+            &url,
+            CredentialWrite::StoreJwt {
+                username: &req.username,
+                token: &token,
+            },
+        )
+        .await?;
         Ok((req.username, token))
     } else {
         let resp = resp.json::<ErrorMsg>().await.map_err(RequestError::from)?;
@@ -298,7 +214,15 @@ where
         let token = resp.token;
         if let Some(cred_path) = cred_path {
             let cred_path = cred_path.get_path_buf();
-            modify_or_append_credential(&cred_path, &user_login.username, &token).await?;
+            CredentialStore::write(
+                &cred_path,
+                &*url,
+                CredentialWrite::StoreJwt {
+                    username: &user_login.username,
+                    token: &token,
+                },
+            )
+            .await?;
         }
         Ok(token)
     } else {

--- a/netmito/src/service/auth/credential_store.rs
+++ b/netmito/src/service/auth/credential_store.rs
@@ -1,0 +1,249 @@
+use std::{io, path::Path};
+
+use base64::{engine::general_purpose, Engine as _};
+use tokio::io::AsyncBufReadExt;
+use url::Url;
+
+pub(crate) enum Credential {
+    Jwt {
+        username: String,
+        token: String,
+    },
+    #[allow(dead_code)]
+    Login {
+        username: String,
+        md5_password: [u8; 16],
+    },
+}
+
+pub(crate) enum CredentialRead<'a> {
+    Jwt {
+        username: Option<&'a str>,
+    },
+    #[allow(dead_code)]
+    Login {
+        username: &'a str,
+    },
+}
+
+pub(crate) enum CredentialWrite<'a> {
+    StoreJwt {
+        username: &'a str,
+        token: &'a str,
+    },
+    #[allow(dead_code)]
+    StoreLogin {
+        username: &'a str,
+        md5_password: &'a [u8; 16],
+    },
+    RemoveJwt {
+        username: &'a str,
+    },
+}
+
+pub(crate) struct CredentialStore;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CredentialKind {
+    Jwt,
+    Login,
+}
+
+struct ParsedCredential<'a> {
+    encoded_origin: &'a str,
+    username: &'a str,
+    value: ParsedCredentialValue<'a>,
+}
+
+enum ParsedCredentialValue<'a> {
+    Jwt(&'a str),
+    Login([u8; 16]),
+}
+
+impl ParsedCredentialValue<'_> {
+    fn kind(&self) -> CredentialKind {
+        match self {
+            Self::Jwt(_) => CredentialKind::Jwt,
+            Self::Login(_) => CredentialKind::Login,
+        }
+    }
+}
+
+fn encode_origin(coordinator_url: &Url) -> String {
+    general_purpose::STANDARD.encode(coordinator_url.origin().ascii_serialization())
+}
+
+fn parse_credential(line: &str) -> Option<ParsedCredential<'_>> {
+    let mut fields = line.split(':');
+    let (Some(encoded_origin), Some(username), Some(typed_credential), None) =
+        (fields.next(), fields.next(), fields.next(), fields.next())
+    else {
+        return None;
+    };
+
+    let (kind, value) = typed_credential.split_once('=')?;
+    let value = match kind {
+        "jwt" => ParsedCredentialValue::Jwt(value),
+        "login" => {
+            let md5_password = general_purpose::STANDARD
+                .decode(value)
+                .ok()?
+                .try_into()
+                .ok()?;
+            ParsedCredentialValue::Login(md5_password)
+        }
+        _ => return None,
+    };
+
+    Some(ParsedCredential {
+        encoded_origin,
+        username,
+        value,
+    })
+}
+
+impl CredentialStore {
+    pub(crate) async fn read(
+        credential_path: &Path,
+        coordinator_url: &Url,
+        request: CredentialRead<'_>,
+    ) -> io::Result<Option<Credential>> {
+        let Ok(file) = tokio::fs::File::open(credential_path).await else {
+            return Ok(None);
+        };
+
+        let encoded_origin = encode_origin(coordinator_url);
+        let mut lines = tokio::io::BufReader::new(file).lines();
+
+        while let Some(line) = lines.next_line().await? {
+            let Some(credential) = parse_credential(&line) else {
+                continue;
+            };
+            let ParsedCredential {
+                encoded_origin: stored_origin,
+                username,
+                value,
+            } = credential;
+
+            if stored_origin != encoded_origin.as_str() {
+                continue;
+            }
+
+            match (&request, value) {
+                (
+                    CredentialRead::Jwt {
+                        username: requested,
+                    },
+                    ParsedCredentialValue::Jwt(token),
+                ) if match requested {
+                    Some(requested) => *requested == username,
+                    None => true,
+                } =>
+                {
+                    return Ok(Some(Credential::Jwt {
+                        username: username.to_owned(),
+                        token: token.to_owned(),
+                    }));
+                }
+                (
+                    CredentialRead::Login {
+                        username: requested,
+                    },
+                    ParsedCredentialValue::Login(md5_password),
+                ) if *requested == username => {
+                    return Ok(Some(Credential::Login {
+                        username: username.to_owned(),
+                        md5_password,
+                    }));
+                }
+                _ => {}
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub(crate) async fn write(
+        credential_path: &Path,
+        coordinator_url: &Url,
+        operation: CredentialWrite<'_>,
+    ) -> io::Result<()> {
+        let encoded_origin = encode_origin(coordinator_url);
+        let (username, kind, replacement) = match operation {
+            CredentialWrite::StoreJwt { username, token } => (
+                username,
+                CredentialKind::Jwt,
+                Some(format!("{encoded_origin}:{username}:jwt={token}")),
+            ),
+            CredentialWrite::StoreLogin {
+                username,
+                md5_password,
+            } => {
+                let md5_password = general_purpose::STANDARD.encode(md5_password);
+                (
+                    username,
+                    CredentialKind::Login,
+                    Some(format!("{encoded_origin}:{username}:login={md5_password}")),
+                )
+            }
+            CredentialWrite::RemoveJwt { username } => (username, CredentialKind::Jwt, None),
+        };
+
+        if replacement.is_some() {
+            if let Some(parent) = credential_path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+            {
+                tokio::fs::create_dir_all(parent).await?;
+            }
+        }
+
+        let file = match tokio::fs::File::open(credential_path).await {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                if let Some(replacement) = replacement.as_deref() {
+                    tokio::fs::write(credential_path, replacement).await?;
+                }
+                return Ok(());
+            }
+            Err(error) => return Err(error),
+        };
+        let mut lines = tokio::io::BufReader::new(file).lines();
+        let mut new_lines = Vec::new();
+        let mut found = false;
+
+        while let Some(line) = lines.next_line().await? {
+            let matches = match parse_credential(&line) {
+                Some(credential) => {
+                    credential.encoded_origin == encoded_origin.as_str()
+                        && credential.username == username
+                        && credential.value.kind() == kind
+                }
+                None => false,
+            };
+
+            if matches {
+                found = true;
+                if let Some(replacement) = replacement.as_ref() {
+                    new_lines.push(replacement.clone());
+                }
+            } else {
+                new_lines.push(line);
+            }
+        }
+
+        if !found {
+            if let Some(replacement) = replacement {
+                new_lines.push(replacement);
+            }
+        }
+
+        if new_lines.is_empty() {
+            tokio::fs::remove_file(credential_path).await?;
+        } else {
+            tokio::fs::write(credential_path, new_lines.join("\n")).await?;
+        }
+
+        Ok(())
+    }
+}

--- a/netmito/src/service/auth/credential_store.rs
+++ b/netmito/src/service/auth/credential_store.rs
@@ -1,6 +1,5 @@
 use std::{io, path::PathBuf};
 
-use base64::{engine::general_purpose, Engine as _};
 use tokio::io::AsyncBufReadExt;
 use url::Url;
 
@@ -10,67 +9,28 @@ pub(crate) struct CredentialStore {
     credential_path: PathBuf,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum CredentialKind {
-    Jwt,
-    Login,
-}
-
 struct ParsedCredential<'a> {
-    encoded_origin: &'a str,
+    origin: &'a str,
     username: &'a str,
-    value: ParsedCredentialValue<'a>,
+    token: &'a str,
 }
 
-enum ParsedCredentialValue<'a> {
-    Jwt(&'a str),
-    Login([u8; 16]),
-}
-
-impl ParsedCredentialValue<'_> {
-    fn kind(&self) -> CredentialKind {
-        match self {
-            Self::Jwt(_) => CredentialKind::Jwt,
-            Self::Login(_) => CredentialKind::Login,
-        }
-    }
-}
-
-enum StoredCredential {
-    Jwt { username: String, token: String },
-    Login([u8; 16]),
-}
-
-fn encode_origin(coordinator_url: &Url) -> String {
-    general_purpose::STANDARD.encode(coordinator_url.origin().ascii_serialization())
+fn normalize_origin(coordinator_url: &Url) -> String {
+    coordinator_url.origin().ascii_serialization()
 }
 
 fn parse_credential(line: &str) -> Option<ParsedCredential<'_>> {
-    let mut fields = line.split(':');
-    let (Some(encoded_origin), Some(username), Some(typed_credential), None) =
+    let mut fields = line.split(',');
+    let (Some(origin), Some(username), Some(token), None) =
         (fields.next(), fields.next(), fields.next(), fields.next())
     else {
         return None;
     };
 
-    let (kind, value) = typed_credential.split_once('=')?;
-    let value = match kind {
-        "jwt" => ParsedCredentialValue::Jwt(value),
-        "login" => {
-            let md5_password = general_purpose::STANDARD
-                .decode(value)
-                .ok()?
-                .try_into()
-                .ok()?;
-            ParsedCredentialValue::Login(md5_password)
-        }
-        _ => return None,
-    };
-
     Some(ParsedCredential {
-        encoded_origin,
+        origin,
         username,
-        value,
+        token,
     })
 }
 
@@ -96,13 +56,7 @@ impl CredentialStore {
         coordinator_url: &Url,
         username: Option<&str>,
     ) -> io::Result<Option<(String, String)>> {
-        match self
-            .read(coordinator_url, username, CredentialKind::Jwt)
-            .await?
-        {
-            Some(StoredCredential::Jwt { username, token }) => Ok(Some((username, token))),
-            _ => Ok(None),
-        }
+        self.read(coordinator_url, username).await
     }
 
     pub(crate) async fn write_jwt(
@@ -111,71 +65,28 @@ impl CredentialStore {
         username: &str,
         token: &str,
     ) -> io::Result<()> {
-        let encoded_origin = encode_origin(coordinator_url);
-        let replacement = format!("{encoded_origin}:{username}:jwt={token}");
+        let origin = normalize_origin(coordinator_url);
+        let replacement = format!("{origin},{username},{token}");
 
-        self.rewrite(
-            &encoded_origin,
-            username,
-            CredentialKind::Jwt,
-            Some(replacement),
-        )
-        .await
-    }
-
-    #[allow(dead_code)]
-    pub(crate) async fn read_login(
-        &self,
-        coordinator_url: &Url,
-        username: &str,
-    ) -> io::Result<Option<[u8; 16]>> {
-        match self
-            .read(coordinator_url, Some(username), CredentialKind::Login)
-            .await?
-        {
-            Some(StoredCredential::Login(md5_password)) => Ok(Some(md5_password)),
-            _ => Ok(None),
-        }
-    }
-
-    #[allow(dead_code)]
-    pub(crate) async fn write_login(
-        &self,
-        coordinator_url: &Url,
-        username: &str,
-        md5_password: &[u8; 16],
-    ) -> io::Result<()> {
-        let encoded_origin = encode_origin(coordinator_url);
-        let md5_password = general_purpose::STANDARD.encode(md5_password);
-        let replacement = format!("{encoded_origin}:{username}:login={md5_password}");
-
-        self.rewrite(
-            &encoded_origin,
-            username,
-            CredentialKind::Login,
-            Some(replacement),
-        )
-        .await
+        self.rewrite(&origin, username, Some(replacement)).await
     }
 
     pub(crate) async fn remove_jwt(&self, coordinator_url: &Url, username: &str) -> io::Result<()> {
-        let encoded_origin = encode_origin(coordinator_url);
+        let origin = normalize_origin(coordinator_url);
 
-        self.rewrite(&encoded_origin, username, CredentialKind::Jwt, None)
-            .await
+        self.rewrite(&origin, username, None).await
     }
 
     async fn read(
         &self,
         coordinator_url: &Url,
         requested_username: Option<&str>,
-        kind: CredentialKind,
-    ) -> io::Result<Option<StoredCredential>> {
+    ) -> io::Result<Option<(String, String)>> {
         let Ok(file) = tokio::fs::File::open(&self.credential_path).await else {
             return Ok(None);
         };
 
-        let encoded_origin = encode_origin(coordinator_url);
+        let origin = normalize_origin(coordinator_url);
         let mut lines = tokio::io::BufReader::new(file).lines();
 
         while let Some(line) = lines.next_line().await? {
@@ -184,12 +95,12 @@ impl CredentialStore {
             };
 
             let ParsedCredential {
-                encoded_origin: stored_origin,
+                origin: stored_origin,
                 username,
-                value,
+                token,
             } = credential;
 
-            if stored_origin != encoded_origin.as_str() || value.kind() != kind {
+            if stored_origin != origin.as_str() {
                 continue;
             }
 
@@ -199,13 +110,7 @@ impl CredentialStore {
                 }
             }
 
-            return Ok(Some(match value {
-                ParsedCredentialValue::Jwt(token) => StoredCredential::Jwt {
-                    username: username.to_owned(),
-                    token: token.to_owned(),
-                },
-                ParsedCredentialValue::Login(md5_password) => StoredCredential::Login(md5_password),
-            }));
+            return Ok(Some((username.to_owned(), token.to_owned())));
         }
 
         Ok(None)
@@ -213,9 +118,8 @@ impl CredentialStore {
 
     async fn rewrite(
         &self,
-        encoded_origin: &str,
+        origin: &str,
         username: &str,
-        kind: CredentialKind,
         replacement: Option<String>,
     ) -> io::Result<()> {
         if replacement.is_some() {
@@ -245,11 +149,7 @@ impl CredentialStore {
 
         while let Some(line) = lines.next_line().await? {
             let matches = match parse_credential(&line) {
-                Some(credential) => {
-                    credential.encoded_origin == encoded_origin
-                        && credential.username == username
-                        && credential.value.kind() == kind
-                }
+                Some(credential) => credential.origin == origin && credential.username == username,
                 None => false,
             };
 
@@ -276,5 +176,72 @@ impl CredentialStore {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn normalized_origin(url: &str) -> String {
+        normalize_origin(&Url::parse(url).expect("test URL should be valid"))
+    }
+
+    #[test]
+    fn normalize_equivalent_http_origins() {
+        for url in [
+            "http://127.0.0.1/",
+            "http://127.0.0.1",
+            "http://127.0.0.1:80",
+            "http://127.0.0.1:80/",
+        ] {
+            assert_eq!(normalized_origin(url), "http://127.0.0.1");
+        }
+    }
+
+    #[test]
+    fn normalize_origin_preserves_identity_differences() {
+        assert_eq!(
+            normalized_origin("https://example.com:443/"),
+            "https://example.com"
+        );
+        assert_eq!(
+            normalized_origin("http://example.com:5000/"),
+            "http://example.com:5000"
+        );
+        assert_ne!(
+            normalized_origin("http://example.com"),
+            normalized_origin("https://example.com")
+        );
+        assert_ne!(
+            normalized_origin("http://example.com"),
+            normalized_origin("http://example.org")
+        );
+        assert_eq!(
+            normalized_origin("http://example.com/path?q=1#section"),
+            "http://example.com"
+        );
+        assert_ne!(
+            normalized_origin("http://example.com:5000"),
+            normalized_origin("http://example.com:5001")
+        );
+        assert_ne!(
+            normalized_origin("http://localhost"),
+            normalized_origin("http://127.0.0.1")
+        );
+    }
+
+    #[test]
+    fn parse_comma_separated_credential() {
+        let credential = parse_credential("http://127.0.0.1,user_a,encoded-token==")
+            .expect("credential should be valid");
+
+        assert_eq!(credential.origin, "http://127.0.0.1");
+        assert_eq!(credential.username, "user_a");
+        assert_eq!(credential.token, "encoded-token==");
+
+        assert!(parse_credential("user_a:legacy-token").is_none());
+        assert!(parse_credential("http://127.0.0.1,user_a").is_none());
+        assert!(parse_credential("http://127.0.0.1,user_a,token,extra").is_none());
     }
 }

--- a/netmito/src/service/auth/credential_store.rs
+++ b/netmito/src/service/auth/credential_store.rs
@@ -1,47 +1,14 @@
-use std::{io, path::Path};
+use std::{io, path::PathBuf};
 
 use base64::{engine::general_purpose, Engine as _};
 use tokio::io::AsyncBufReadExt;
 use url::Url;
 
-pub(crate) enum Credential {
-    Jwt {
-        username: String,
-        token: String,
-    },
-    #[allow(dead_code)]
-    Login {
-        username: String,
-        md5_password: [u8; 16],
-    },
-}
+use crate::error::Error;
 
-pub(crate) enum CredentialRead<'a> {
-    Jwt {
-        username: Option<&'a str>,
-    },
-    #[allow(dead_code)]
-    Login {
-        username: &'a str,
-    },
+pub(crate) struct CredentialStore {
+    credential_path: PathBuf,
 }
-
-pub(crate) enum CredentialWrite<'a> {
-    StoreJwt {
-        username: &'a str,
-        token: &'a str,
-    },
-    #[allow(dead_code)]
-    StoreLogin {
-        username: &'a str,
-        md5_password: &'a [u8; 16],
-    },
-    RemoveJwt {
-        username: &'a str,
-    },
-}
-
-pub(crate) struct CredentialStore;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum CredentialKind {
@@ -67,6 +34,11 @@ impl ParsedCredentialValue<'_> {
             Self::Login(_) => CredentialKind::Login,
         }
     }
+}
+
+enum StoredCredential {
+    Jwt { username: String, token: String },
+    Login([u8; 16]),
 }
 
 fn encode_origin(coordinator_url: &Url) -> String {
@@ -103,12 +75,103 @@ fn parse_credential(line: &str) -> Option<ParsedCredential<'_>> {
 }
 
 impl CredentialStore {
-    pub(crate) async fn read(
-        credential_path: &Path,
+    pub(crate) fn new(credential_path: Option<PathBuf>) -> crate::error::Result<Self> {
+        let credential_path = credential_path
+            .or_else(|| {
+                dirs::config_dir().map(|mut path| {
+                    path.push("mitosis");
+                    path.push("credentials");
+                    path
+                })
+            })
+            .ok_or(Error::ConfigError(Box::new(figment::Error::from(
+                "credential path not found",
+            ))))?;
+
+        Ok(Self { credential_path })
+    }
+
+    pub(crate) async fn read_jwt(
+        &self,
         coordinator_url: &Url,
-        request: CredentialRead<'_>,
-    ) -> io::Result<Option<Credential>> {
-        let Ok(file) = tokio::fs::File::open(credential_path).await else {
+        username: Option<&str>,
+    ) -> io::Result<Option<(String, String)>> {
+        match self
+            .read(coordinator_url, username, CredentialKind::Jwt)
+            .await?
+        {
+            Some(StoredCredential::Jwt { username, token }) => Ok(Some((username, token))),
+            _ => Ok(None),
+        }
+    }
+
+    pub(crate) async fn write_jwt(
+        &self,
+        coordinator_url: &Url,
+        username: &str,
+        token: &str,
+    ) -> io::Result<()> {
+        let encoded_origin = encode_origin(coordinator_url);
+        let replacement = format!("{encoded_origin}:{username}:jwt={token}");
+
+        self.rewrite(
+            &encoded_origin,
+            username,
+            CredentialKind::Jwt,
+            Some(replacement),
+        )
+        .await
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn read_login(
+        &self,
+        coordinator_url: &Url,
+        username: &str,
+    ) -> io::Result<Option<[u8; 16]>> {
+        match self
+            .read(coordinator_url, Some(username), CredentialKind::Login)
+            .await?
+        {
+            Some(StoredCredential::Login(md5_password)) => Ok(Some(md5_password)),
+            _ => Ok(None),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn write_login(
+        &self,
+        coordinator_url: &Url,
+        username: &str,
+        md5_password: &[u8; 16],
+    ) -> io::Result<()> {
+        let encoded_origin = encode_origin(coordinator_url);
+        let md5_password = general_purpose::STANDARD.encode(md5_password);
+        let replacement = format!("{encoded_origin}:{username}:login={md5_password}");
+
+        self.rewrite(
+            &encoded_origin,
+            username,
+            CredentialKind::Login,
+            Some(replacement),
+        )
+        .await
+    }
+
+    pub(crate) async fn remove_jwt(&self, coordinator_url: &Url, username: &str) -> io::Result<()> {
+        let encoded_origin = encode_origin(coordinator_url);
+
+        self.rewrite(&encoded_origin, username, CredentialKind::Jwt, None)
+            .await
+    }
+
+    async fn read(
+        &self,
+        coordinator_url: &Url,
+        requested_username: Option<&str>,
+        kind: CredentialKind,
+    ) -> io::Result<Option<StoredCredential>> {
+        let Ok(file) = tokio::fs::File::open(&self.credential_path).await else {
             return Ok(None);
         };
 
@@ -119,78 +182,45 @@ impl CredentialStore {
             let Some(credential) = parse_credential(&line) else {
                 continue;
             };
+
             let ParsedCredential {
                 encoded_origin: stored_origin,
                 username,
                 value,
             } = credential;
 
-            if stored_origin != encoded_origin.as_str() {
+            if stored_origin != encoded_origin.as_str() || value.kind() != kind {
                 continue;
             }
 
-            match (&request, value) {
-                (
-                    CredentialRead::Jwt {
-                        username: requested,
-                    },
-                    ParsedCredentialValue::Jwt(token),
-                ) if match requested {
-                    Some(requested) => *requested == username,
-                    None => true,
-                } =>
-                {
-                    return Ok(Some(Credential::Jwt {
-                        username: username.to_owned(),
-                        token: token.to_owned(),
-                    }));
+            if let Some(requested_username) = requested_username {
+                if requested_username != username {
+                    continue;
                 }
-                (
-                    CredentialRead::Login {
-                        username: requested,
-                    },
-                    ParsedCredentialValue::Login(md5_password),
-                ) if *requested == username => {
-                    return Ok(Some(Credential::Login {
-                        username: username.to_owned(),
-                        md5_password,
-                    }));
-                }
-                _ => {}
             }
+
+            return Ok(Some(match value {
+                ParsedCredentialValue::Jwt(token) => StoredCredential::Jwt {
+                    username: username.to_owned(),
+                    token: token.to_owned(),
+                },
+                ParsedCredentialValue::Login(md5_password) => StoredCredential::Login(md5_password),
+            }));
         }
 
         Ok(None)
     }
 
-    pub(crate) async fn write(
-        credential_path: &Path,
-        coordinator_url: &Url,
-        operation: CredentialWrite<'_>,
+    async fn rewrite(
+        &self,
+        encoded_origin: &str,
+        username: &str,
+        kind: CredentialKind,
+        replacement: Option<String>,
     ) -> io::Result<()> {
-        let encoded_origin = encode_origin(coordinator_url);
-        let (username, kind, replacement) = match operation {
-            CredentialWrite::StoreJwt { username, token } => (
-                username,
-                CredentialKind::Jwt,
-                Some(format!("{encoded_origin}:{username}:jwt={token}")),
-            ),
-            CredentialWrite::StoreLogin {
-                username,
-                md5_password,
-            } => {
-                let md5_password = general_purpose::STANDARD.encode(md5_password);
-                (
-                    username,
-                    CredentialKind::Login,
-                    Some(format!("{encoded_origin}:{username}:login={md5_password}")),
-                )
-            }
-            CredentialWrite::RemoveJwt { username } => (username, CredentialKind::Jwt, None),
-        };
-
         if replacement.is_some() {
-            if let Some(parent) = credential_path
+            if let Some(parent) = self
+                .credential_path
                 .parent()
                 .filter(|parent| !parent.as_os_str().is_empty())
             {
@@ -198,16 +228,17 @@ impl CredentialStore {
             }
         }
 
-        let file = match tokio::fs::File::open(credential_path).await {
+        let file = match tokio::fs::File::open(&self.credential_path).await {
             Ok(file) => file,
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
                 if let Some(replacement) = replacement.as_deref() {
-                    tokio::fs::write(credential_path, replacement).await?;
+                    tokio::fs::write(&self.credential_path, replacement).await?;
                 }
                 return Ok(());
             }
             Err(error) => return Err(error),
         };
+
         let mut lines = tokio::io::BufReader::new(file).lines();
         let mut new_lines = Vec::new();
         let mut found = false;
@@ -215,7 +246,7 @@ impl CredentialStore {
         while let Some(line) = lines.next_line().await? {
             let matches = match parse_credential(&line) {
                 Some(credential) => {
-                    credential.encoded_origin == encoded_origin.as_str()
+                    credential.encoded_origin == encoded_origin
                         && credential.username == username
                         && credential.value.kind() == kind
                 }
@@ -239,9 +270,9 @@ impl CredentialStore {
         }
 
         if new_lines.is_empty() {
-            tokio::fs::remove_file(credential_path).await?;
+            tokio::fs::remove_file(&self.credential_path).await?;
         } else {
-            tokio::fs::write(credential_path, new_lines.join("\n")).await?;
+            tokio::fs::write(&self.credential_path, new_lines.join("\n")).await?;
         }
 
         Ok(())

--- a/netmito/src/service/auth/mod.rs
+++ b/netmito/src/service/auth/mod.rs
@@ -1,4 +1,5 @@
 pub mod cred;
+pub(crate) mod credential_store;
 pub mod token;
 
 use std::{io::Write, net::SocketAddr};

--- a/netmito/src/worker.rs
+++ b/netmito/src/worker.rs
@@ -32,7 +32,7 @@ use crate::{
     config::{WorkerConfig, WorkerConfigCli},
     error::{Error, ErrorMsg},
     schema::{RegisterWorkerReq, RegisterWorkerResp},
-    service::auth::cred::get_user_credential,
+    service::auth::{cred::get_user_credential, credential_store::CredentialStore},
     signal::shutdown_signal,
 };
 
@@ -251,8 +251,14 @@ impl MitoWorker {
     pub async fn setup(mut config: WorkerConfig) -> crate::error::Result<(Self, TracingGuard)> {
         tracing::debug!("Worker is setting up");
         let http_client = Client::new();
+        let credential_store = CredentialStore::new(
+            config
+                .credential_path
+                .as_ref()
+                .map(|credential_path| credential_path.relative()),
+        )?;
         let (_, credential) = get_user_credential(
-            config.credential_path.as_ref(),
+            &credential_store,
             &http_client,
             config.coordinator_addr.clone(),
             config.user.take(),


### PR DESCRIPTION
## Summary

- Introduce a crate-private `CredentialStore` to centralize credential path resolution and file operations.
- Route Client and Worker JWT cache reads, writes, updates, and removals through `CredentialStore`.
- Store cached JWTs in a readable `normalized_origin,username,token` format.
- Scope cached JWTs by normalized Coordinator origin and username.
- Preserve the existing authentication flow and token encoding.
- Do not persist login passwords.
- Initialize the Client credential store during `MitoHttpClient` construction and share a single credential-loading path between Client and Worker.

## Validation

- Added unit tests verifying that:
  - trailing-slash and default-port aliases normalize to the same Coordinator origin;
  - different schemes, hosts, and non-default ports remain distinct;
  - paths, queries, and fragments do not affect Coordinator identity;
  - comma-separated credential entries are parsed correctly.
- Manually verified that:
  - cached tokens use the readable three-field format;
  - cached authentication reuses the existing token without falling back to login;
  - trailing-slash aliases reuse the same cached credential;
  - refresh updates the cached token without appending another record;
  - revoke removes the matching cached token.